### PR TITLE
Cli lambda

### DIFF
--- a/docs/source/query_index.md
+++ b/docs/source/query_index.md
@@ -39,6 +39,10 @@ file can be built with the following command:
     $ ./bin/create_wand_data -c ../test/test_data/test_collection -o test_collection.wand
 
 If you want to compress the file append `--compress` at the end of the command.
+When using variable-sized blocks (for VBMW) via the `--variable-block` parameter,
+you can also specify lambda with the `-l <float>` or `--lambda <float>` flags. 
+The value of lambda impacts the mean size of the variable blocks that are
+output. See the VBMW paper (listed below) for more details.
 
 
 ## Query algorithms

--- a/include/pisa/wand_data.hpp
+++ b/include/pisa/wand_data.hpp
@@ -22,7 +22,7 @@ namespace pisa {
 
         template<typename LengthsIterator>
         wand_data(LengthsIterator len_it, uint64_t num_docs,
-                      binary_freq_collection const &coll, partition_type type = partition_type::fixed_blocks) {
+                      binary_freq_collection const &coll, partition_type type = partition_type::fixed_blocks, const float lambda = 0.0f) {
             std::vector<float> norm_lens(num_docs);
             std::vector<float> max_term_weight;
             global_parameters params;
@@ -44,7 +44,7 @@ namespace pisa {
             {
                 pisa::progress progress("Processing posting lists", coll.size());
                 for (auto const &seq: coll) {
-                    auto v = builder.add_sequence(seq, coll, norm_lens);
+                    auto v = builder.add_sequence(seq, coll, norm_lens, lambda);
                     max_term_weight.push_back(v);
                     progress.update(1);
                 }

--- a/include/pisa/wand_data_compressed.hpp
+++ b/include/pisa/wand_data_compressed.hpp
@@ -111,12 +111,12 @@ namespace {
                 spdlog::info("Storing max weight for each list and for each block...");
             }
 
-            float add_sequence(binary_freq_collection::sequence const &seq, binary_freq_collection const &coll, std::vector<float> const & norm_lens){
+            float add_sequence(binary_freq_collection::sequence const &seq, binary_freq_collection const &coll, std::vector<float> const & norm_lens, const float lambda = 0.0f){
 
                 if (seq.docs.size() > configuration::get().threshold_wand_list) {
 
                     auto t = ((type == partition_type::fixed_blocks) ? static_block_partition(seq, norm_lens)
-                                                      : variable_block_partition(coll, seq, norm_lens));
+                                                      : variable_block_partition(coll, seq, norm_lens, lambda));
 
                     auto ind = compressor_builder.compress_data(t.second);
 

--- a/include/pisa/wand_data_raw.hpp
+++ b/include/pisa/wand_data_raw.hpp
@@ -33,12 +33,12 @@ namespace pisa {
                 blocks_start.push_back(0);
             }
 
-            float add_sequence(binary_freq_collection::sequence const &seq, binary_freq_collection const &coll, std::vector<float> const & norm_lens){
+            float add_sequence(binary_freq_collection::sequence const &seq, binary_freq_collection const &coll, std::vector<float> const & norm_lens, const float lambda = 0.0f){
 
                 if (seq.docs.size() > configuration::get().threshold_wand_list) {
 
                     auto t = ((type == partition_type::fixed_blocks) ? static_block_partition(seq, norm_lens)
-                                                      : variable_block_partition(coll, seq, norm_lens));
+                                                      : variable_block_partition(coll, seq, norm_lens, lambda));
 
                     block_max_term_weight.insert(block_max_term_weight.end(), t.second.begin(),
                                                  t.second.end());

--- a/include/pisa/wand_utils.hpp
+++ b/include/pisa/wand_utils.hpp
@@ -46,11 +46,15 @@ template <typename Scorer = bm25>
 std::pair<std::vector<uint32_t>, std::vector<float>>
 variable_block_partition(binary_freq_collection const &coll,
                          binary_freq_collection::sequence const &seq,
-                         std::vector<float> const &norm_lens) {
+                         std::vector<float> const &norm_lens,
+                         const float lambda = 0.0f) {
 
   auto eps1 = configuration::get().eps1_wand;
   auto eps2 = configuration::get().eps2_wand;
   auto fixed_cost = configuration::get().fixed_cost_wand_partition;
+  // Use input param
+  if (lambda != 0.0f)
+      fixed_cost = lambda;
 
   // Auxiliary vector
   using doc_score_t = std::pair<uint64_t, float>;

--- a/src/create_wand_data.cpp
+++ b/src/create_wand_data.cpp
@@ -16,6 +16,7 @@
 int main(int argc, const char **argv) {
     using namespace pisa;
 
+    float lambda = 0.0f;
     std::string input_basename;
     std::string output_filename;
     bool        variable_block = false;
@@ -24,6 +25,7 @@ int main(int argc, const char **argv) {
     CLI::App app{"create_wand_data - a tool for creating additional data for query processing."};
     app.add_option("-c,--collection", input_basename, "Collection basename")->required();
     app.add_option("-o,--output", output_filename, "Output filename")->required();
+    app.add_option("-l,--lambda", lambda, "Lambda parameter for variable blocks");
     app.add_flag("--variable-block", variable_block, "Variable length blocks");
     app.add_flag("--compress", compress, "Compress additional data");
     CLI11_PARSE(app, argc, argv);
@@ -40,11 +42,11 @@ int main(int argc, const char **argv) {
 
     if (compress) {
         wand_data<bm25, wand_data_compressed<bm25, uniform_score_compressor>> wdata(
-            sizes_coll.begin()->begin(), coll.num_docs(), coll, p_type);
+            sizes_coll.begin()->begin(), coll.num_docs(), coll, p_type, lambda);
         mapper::freeze(wdata, output_filename.c_str());
     } else {
         wand_data<bm25, wand_data_raw<bm25>> wdata(
-            sizes_coll.begin()->begin(), coll.num_docs(), coll, p_type);
+            sizes_coll.begin()->begin(), coll.num_docs(), coll, p_type, lambda);
         mapper::freeze(wdata, output_filename.c_str());
     }
 }


### PR DESCRIPTION
Added a small change which allows lambda to be set via command line arguments instead of directly out of the config file (avoids recompilation if searching for the right block size on a new collection).

Also added a small bit of text to the documentation.