### PR TITLE
Fix issue with per-query timings

### DIFF
--- a/src/queries.cpp
+++ b/src/queries.cpp
@@ -47,7 +47,7 @@ void extract_times(Fn fn,
                        [&]() { do_not_optimize_away(fn(terms)); })
                 .count();
         });
-        auto mean = std::accumulate(times.begin(), times.end(), std::size_t{0}, std::plus<>());
+        auto mean = std::accumulate(times.begin(), times.end(), std::size_t{0}, std::plus<>()) / runs;
         os << fmt::format("{}\t{}\n", query.id.value_or(std::to_string(qid)), mean);
     }
 }


### PR DESCRIPTION
I am pretty sure we need to divide through by the number of runs here (please double check this).