### PR TITLE
Add heap score check to accumulation of top-k heap

### DIFF
--- a/include/pisa/accumulator/lazy_accumulator.hpp
+++ b/include/pisa/accumulator/lazy_accumulator.hpp
@@ -74,7 +74,7 @@ struct Lazy_Accumulator {
         for (auto const &block : m_accumulators) {
             int pos = 0;
             for (auto const &score : block.accumulators) {
-                if (block.counter(pos++) == m_counter) {
+                if (block.counter(pos++) == m_counter && topk.would_enter(score)) {
                     topk.insert(score, docid);
                 }
                 ++docid;

--- a/include/pisa/accumulator/simple_accumulator.hpp
+++ b/include/pisa/accumulator/simple_accumulator.hpp
@@ -13,7 +13,7 @@ struct Simple_Accumulator : public std::vector<float> {
     void accumulate(uint32_t doc, float score) { operator[](doc) += score; }
     void aggregate(topk_queue &topk) {
         uint64_t docid = 0u;
-        std::for_each(begin(), end(), [&](auto score) { topk.insert(score, docid++); });
+        std::for_each(begin(), end(), [&](auto score) { if(topk.would_enter(score)) { topk.insert(score, docid++); }});
     }
 };
 


### PR DESCRIPTION
I spoke briefly to Michal regarding an issue I found where rarer terms would actually take longer to process in TaaT mode.

After some profiling, it became clear that when there aren't many accumulators touched (so, many tied scores), they were being pushed/popped in the heap. It seems that this is true for any tied score. 

This commit will fix this in the accumulators, but it's probably worth discussing if we should change the heap insert policy to require a "greater than current threshold" rather than a "greater than or equal to threshold" score for heap entry.

The line in question is here: https://github.com/pisa-engine/pisa/blob/49ebb8104d34bc71fe7611a02598ede3a7dffbb3/include/pisa/topk_queue.hpp#L24

