### PR TITLE
Update the heap

### DIFF
--- a/include/pisa/topk_queue.hpp
+++ b/include/pisa/topk_queue.hpp
@@ -21,7 +21,7 @@ struct topk_queue {
     bool insert(float score) { return insert(score, 0); }
 
     bool insert(float score, uint64_t docid) {
-        if (PISA_UNLIKELY(score < m_threshold)) {
+        if (PISA_UNLIKELY(score <= m_threshold)) {
             return false;
         }
         m_q.emplace_back(score, docid);


### PR DESCRIPTION
This will fix issue #150 and allow us to close off #149 without merging it (as this is the alternative solution).

The impact here is a more deterministic processing model, where a document can only make it into the top-k heap if its current score exceeds the heap threshold. This means that, given a query in which all document scores are tied, we would return the first k matching documents.