### PR TITLE
Update ranked_or_query.hpp

### DIFF
--- a/include/pisa/query/algorithm/ranked_or_query.hpp
+++ b/include/pisa/query/algorithm/ranked_or_query.hpp
@@ -37,7 +37,7 @@ struct ranked_or_query {
                 }
             }
 
-            m_topk.insert(score);
+            m_topk.insert(score, cur_doc);
             cur_doc = next_doc;
         }
 


### PR DESCRIPTION
The reason with `ranked_or` is failing with `evaluate_queries` is because we are not storing the document ID, so the result set consists of document ID 0 only.