### PR TITLE
Remove boost::te

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -58,9 +58,6 @@
 [submodule "external/range-v3"]
 	path = external/range-v3
 	url = https://github.com/ericniebler/range-v3.git
-[submodule "external/te"]
-	path = external/te
-	url = https://github.com/boost-experimental/te.git
 [submodule "external/trecpp"]
 	path = external/trecpp
 	url = https://github.com/pisa-engine/trecpp.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,7 +95,6 @@ target_link_libraries(pisa INTERFACE
     spdlog
     fmt::fmt
     range-v3
-    te
 )
 target_include_directories(pisa INTERFACE external)
 

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -110,7 +110,3 @@ add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/spdlog)
 
 # Add range-v3
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/range-v3)
-
-# Add Boost.te
-add_library(te INTERFACE)
-target_include_directories(te INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/te/include)

--- a/test/test_forward_index_builder.cpp
+++ b/test/test_forward_index_builder.cpp
@@ -90,12 +90,12 @@ TEST_CASE("Build forward index batch", "[parsing][forward_index]")
 
     GIVEN("a few test records") {
         std::vector<Document_Record> records{
-            Plaintext_Record{"Doc10", "lorem ipsum dolor sit amet consectetur adipiscing elit"},
-            Plaintext_Record{"Doc11", "integer rutrum felis et sagittis dapibus"},
-            Plaintext_Record{"Doc12", "vivamus ac velit nec purus molestie tincidunt"},
-            Plaintext_Record{"Doc13", "vivamus eu quam vitae lacus porta tempus quis eu metus"},
-            Plaintext_Record{"Doc14",
-                             "curabitur a justo vitae turpis feugiat molestie eu ac nunc"}};
+            Document_Record("Doc10", "lorem ipsum dolor sit amet consectetur adipiscing elit", ""),
+            Document_Record("Doc11", "integer rutrum felis et sagittis dapibus", ""),
+            Document_Record("Doc12", "vivamus ac velit nec purus molestie tincidunt", ""),
+            Document_Record("Doc13", "vivamus eu quam vitae lacus porta tempus quis eu metus", ""),
+            Document_Record(
+                "Doc14", "curabitur a justo vitae turpis feugiat molestie eu ac nunc", "")};
         WHEN("write a batch to temp directory") {
             Temporary_Directory tmpdir;
             auto output_file = tmpdir.path() / "fwd";
@@ -301,7 +301,7 @@ TEST_CASE("Build forward index", "[parsing][forward_index][integration]")
     auto next_record = [](std::istream &in) -> std::optional<Document_Record> {
         Plaintext_Record record;
         if (in >> record) {
-            return record;
+            return Document_Record(record.trecid(), record.content(), record.url());
         }
         return std::nullopt;
     };

--- a/test/test_ranked_queries.cpp
+++ b/test/test_ranked_queries.cpp
@@ -1,6 +1,5 @@
 #define CATCH_CONFIG_MAIN
 
-#include <boost/te.hpp>
 #include <catch2/catch.hpp>
 #include <functional>
 


### PR DESCRIPTION
Since there were some problems with compiling `boost::te` on clang 8 and up (even their tests in their repo fail!), I took a look at it, and figured that we don't really need any smart stuff there. We already have different cases depending on a format, so we can simply move data to another object that is later operated on. This is what I'm doing.

This now compiles on clang 8.

But what should we do with travis? We should probably add 7 and 8 but that's another ~40 minutes of testing time. I think we should, at least for the time being, just skip 5 and 6. After all, we only test gcc 7 and 8, so why is clang any different? Plus we're testing whatever's on mac. I think that's enough.