### PR TITLE
Parallel evaluate

### DIFF
--- a/src/evaluate_queries.cpp
+++ b/src/evaluate_queries.cpp
@@ -129,7 +129,7 @@ void evaluate_queries(const std::string &index_filename,
         std::stringstream result_list;
         for (auto && [ rank, result ] : enumerate(results)) {
             result_list << fmt::format("{}\t{}\t{}\t{}\t{}\t{}\n",
-                                     queries[query_idx].id.value_or(std::to_string(0)),
+                                     qid.value_or(std::to_string(0)),
                                      iteration,
                                      docmap[result.second],
                                      rank,

--- a/src/evaluate_queries.cpp
+++ b/src/evaluate_queries.cpp
@@ -12,6 +12,10 @@
 
 #include "mappable/mapper.hpp"
 
+#include <thread>
+#include "tbb/parallel_for.h"
+#include "tbb/task_scheduler_init.h"
+
 #include "cursor/block_max_scored_cursor.hpp"
 #include "cursor/max_scored_cursor.hpp"
 #include "cursor/scored_cursor.hpp"
@@ -118,18 +122,25 @@ void evaluate_queries(const std::string &index_filename,
     auto source = std::make_shared<mio::mmap_source>(documents_filename.c_str());
     auto docmap = Payload_Vector<>::from(*source);
 
-    for (auto const & [ qid, query ] : enumerate(queries)) {
-        auto results = query_fun(query.terms);
+    auto start_batch = std::chrono::steady_clock::now();
+    tbb::parallel_for (size_t(0), size_t(queries.size()), [&] (size_t query_idx) {
+        auto qid = queries[query_idx].id;
+        auto results = query_fun(queries[query_idx].terms);
+        std::stringstream result_list;
         for (auto && [ rank, result ] : enumerate(results)) {
-            std::cout << fmt::format("{}\t{}\t{}\t{}\t{}\t{}\n",
-                                     query.id.value_or(std::to_string(qid)),
+            result_list << fmt::format("{}\t{}\t{}\t{}\t{}\t{}\n",
+                                     queries[query_idx].id.value_or(std::to_string(0)),
                                      iteration,
                                      docmap[result.second],
                                      rank,
                                      result.first,
                                      run_id);
         }
-    }
+        std::cout << result_list.str() << std::endl;
+    });
+    auto end_batch = std::chrono::steady_clock::now();
+    double batch_ms = std::chrono::duration_cast<std::chrono::milliseconds>(end_batch - start_batch).count();
+    spdlog::info("Time taken to process queries: {}ms", batch_ms);
 }
 
 using wand_raw_index = wand_data<bm25, wand_data_raw<bm25>>;
@@ -150,6 +161,7 @@ int main(int argc, const char **argv)
     std::optional<std::string> stopwords_filename;
     std::optional<std::string> stemmer = std::nullopt;
     uint64_t k = configuration::get().k;
+    size_t threads = std::thread::hardware_concurrency();
     bool compressed = false;
 
     CLI::App app{"Retrieves query results in TREC format."};
@@ -159,6 +171,7 @@ int main(int argc, const char **argv)
     app.add_option("-i,--index", index_filename, "Collection basename")->required();
     app.add_option("-w,--wand", wand_data_filename, "Wand data filename");
     app.add_option("-q,--query", query_filename, "Queries filename");
+    app.add_option("--threads", threads, "Thread Count");
     app.add_flag("--compressed-wand", compressed, "Compressed wand input file");
     app.add_option("--stopwords", stopwords_filename, "File containing stopwords to ignore");
     app.add_option("-k", k, "k value");
@@ -166,6 +179,9 @@ int main(int argc, const char **argv)
     app.add_option("--stemmer", stemmer, "Stemmer type")->needs(terms_opt);
     app.add_option("--documents", documents_file, "Document lexicon")->required();
     CLI11_PARSE(app, argc, argv);
+
+    tbb::task_scheduler_init init(threads);
+    spdlog::info("Number of threads: {}", threads);
 
     std::vector<Query> queries;
     auto process_term = query::term_processor(terms_file, stemmer);


### PR DESCRIPTION
First try at parallel evaluate. I will flag some potential issues or design considerations that we may change. This is at least a working prototype for now. Targets #151.

- Line 132 uses a default value (0) for the identifier if it can't use the one from the query object.
- Had to use stringstream to format output so that the call to `std::cout` wasn't garbled due to the threads.
- Added timer into the code which wraps the entire `parallel_for`