### PR TITLE
Block params

### DIFF
--- a/docs/source/query_index.md
+++ b/docs/source/query_index.md
@@ -48,7 +48,11 @@ If you want to compress the file append `--compress` at the end of the command.
 When using variable-sized blocks (for VBMW) via the `--variable-block` parameter,
 you can also specify lambda with the `-l <float>` or `--lambda <float>` flags. 
 The value of lambda impacts the mean size of the variable blocks that are
-output. See the VBMW paper (listed below) for more details.
+output. See the VBMW paper (listed below) for more details. If using fixed-sized
+blocks, which is the default, you can supply the desired block size using the
+`-b <UINT> ` or `--block-size <UINT>` arguments. Note that if using fixed/variable
+sized blocks, and the `-l` or `-b` parameters are not set, the default parameters
+will be used from the configuration file `configuration.hpp`.
 
 
 ## Query algorithms

--- a/include/pisa/wand_data.hpp
+++ b/include/pisa/wand_data.hpp
@@ -4,87 +4,77 @@
 #include "spdlog/spdlog.h"
 
 #include "binary_freq_collection.hpp"
-#include "scorer/bm25.hpp"
 #include "mappable/mappable_vector.hpp"
+#include "scorer/bm25.hpp"
+#include "util/progress.hpp"
 #include "util/util.hpp"
 #include "wand_data_raw.hpp"
-#include "util/progress.hpp"
 
 class enumerator;
 namespace pisa {
 
-    template<typename Scorer=bm25, typename block_wand_type=wand_data_raw<bm25> >
-    class wand_data {
-    public:
+template <typename Scorer = bm25, typename block_wand_type = wand_data_raw<bm25>>
+class wand_data {
+   public:
+    using wand_data_enumerator = typename block_wand_type::enumerator;
 
-        using wand_data_enumerator = typename block_wand_type::enumerator;
+    wand_data() {}
 
-        wand_data() { }
+    template <typename LengthsIterator>
+    wand_data(LengthsIterator len_it,
+              uint64_t num_docs,
+              binary_freq_collection const &coll,
+              BlockSize block_size)
+    {
+        std::vector<float> norm_lens(num_docs);
+        std::vector<float> max_term_weight;
+        global_parameters params;
+        double lens_sum = 0;
+        spdlog::info("Reading sizes...");
 
-        template<typename LengthsIterator>
-        wand_data(LengthsIterator len_it, uint64_t num_docs,
-                      binary_freq_collection const &coll, partition_type type = partition_type::fixed_blocks, boost::variant<float, uint64_t> block_size = uint64_t(0)) {
-            std::vector<float> norm_lens(num_docs);
-            std::vector<float> max_term_weight;
-            global_parameters params;
-            double lens_sum = 0;
-            spdlog::info("Reading sizes...");
+        for (size_t i = 0; i < num_docs; ++i) {
+            float len = *len_it++;
+            norm_lens[i] = len;
+            lens_sum += len;
+        }
 
-            for (size_t i = 0; i < num_docs; ++i) {
-                float len = *len_it++;
-                norm_lens[i] = len;
-                lens_sum += len;
+        float avg_len = float(lens_sum / double(num_docs));
+        for (auto &norm_len : norm_lens) {
+            norm_len /= avg_len;
+        }
+
+        typename block_wand_type::builder builder(coll, params);
+        {
+            pisa::progress progress("Processing posting lists", coll.size());
+            for (auto const &seq : coll) {
+                auto v = builder.add_sequence(seq, coll, norm_lens, block_size);
+                max_term_weight.push_back(v);
+                progress.update(1);
             }
-
-            float avg_len = float(lens_sum / double(num_docs));
-            for(auto& norm_len: norm_lens) {
-                norm_len /= avg_len;
-            }
-
-            typename block_wand_type::builder builder(type, coll, params);
-            {
-                pisa::progress progress("Processing posting lists", coll.size());
-                for (auto const &seq: coll) {
-                    auto v = builder.add_sequence(seq, coll, norm_lens, block_size);
-                    max_term_weight.push_back(v);
-                    progress.update(1);
-                }
-            }
-            builder.build(m_block_wand);
-            m_norm_lens.steal(norm_lens);
-            m_max_term_weight.steal(max_term_weight);
-
         }
+        builder.build(m_block_wand);
+        m_norm_lens.steal(norm_lens);
+        m_max_term_weight.steal(max_term_weight);
+    }
 
-        float norm_len(uint64_t doc_id) const {
-            return m_norm_lens[doc_id];
-        }
+    float norm_len(uint64_t doc_id) const { return m_norm_lens[doc_id]; }
 
-        float max_term_weight(uint64_t list) const {
-            return m_max_term_weight[list];
-        }
+    float max_term_weight(uint64_t list) const { return m_max_term_weight[list]; }
 
+    wand_data_enumerator getenum(size_t i) const { return m_block_wand.get_enum(i); }
 
-        wand_data_enumerator getenum(size_t i) const {
-            return m_block_wand.get_enum(i);
-        }
+    const block_wand_type &get_block_wand() const { return m_block_wand; }
 
-        const block_wand_type& get_block_wand() const {
-            return m_block_wand;
-        }
+    template <typename Visitor>
+    void map(Visitor &visit)
+    {
+        visit(m_block_wand, "m_block_wand")(m_norm_lens, "m_norm_lens")(m_max_term_weight,
+                                                                        "m_max_term_weight");
+    }
 
-        template<typename Visitor>
-        void map(Visitor &visit) {
-            visit
-                    (m_block_wand, "m_block_wand")
-                    (m_norm_lens, "m_norm_lens")
-                    (m_max_term_weight, "m_max_term_weight");
-        }
-
-
-    private:
-        block_wand_type m_block_wand;
-        mapper::mappable_vector<float> m_norm_lens;
-        mapper::mappable_vector<float> m_max_term_weight;
-    };
-}
+   private:
+    block_wand_type m_block_wand;
+    mapper::mappable_vector<float> m_norm_lens;
+    mapper::mappable_vector<float> m_max_term_weight;
+};
+} // namespace pisa

--- a/include/pisa/wand_data.hpp
+++ b/include/pisa/wand_data.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "boost/variant.hpp"
 #include "spdlog/spdlog.h"
 
 #include "binary_freq_collection.hpp"
@@ -22,7 +23,7 @@ namespace pisa {
 
         template<typename LengthsIterator>
         wand_data(LengthsIterator len_it, uint64_t num_docs,
-                      binary_freq_collection const &coll, partition_type type = partition_type::fixed_blocks, const float lambda = 0.0f) {
+                      binary_freq_collection const &coll, partition_type type = partition_type::fixed_blocks, boost::variant<float, uint64_t> block_size = uint64_t(0)) {
             std::vector<float> norm_lens(num_docs);
             std::vector<float> max_term_weight;
             global_parameters params;
@@ -44,7 +45,7 @@ namespace pisa {
             {
                 pisa::progress progress("Processing posting lists", coll.size());
                 for (auto const &seq: coll) {
-                    auto v = builder.add_sequence(seq, coll, norm_lens, lambda);
+                    auto v = builder.add_sequence(seq, coll, norm_lens, block_size);
                     max_term_weight.push_back(v);
                     progress.update(1);
                 }

--- a/include/pisa/wand_data_compressed.hpp
+++ b/include/pisa/wand_data_compressed.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "boost/variant.hpp"
 #include "spdlog/spdlog.h"
 
 #include "binary_freq_collection.hpp"
@@ -111,12 +112,12 @@ namespace {
                 spdlog::info("Storing max weight for each list and for each block...");
             }
 
-            float add_sequence(binary_freq_collection::sequence const &seq, binary_freq_collection const &coll, std::vector<float> const & norm_lens, const float lambda = 0.0f){
+            float add_sequence(binary_freq_collection::sequence const &seq, binary_freq_collection const &coll, std::vector<float> const & norm_lens, boost::variant<float, uint64_t> block_size = uint64_t(0)){
 
                 if (seq.docs.size() > configuration::get().threshold_wand_list) {
 
-                    auto t = ((type == partition_type::fixed_blocks) ? static_block_partition(seq, norm_lens)
-                                                      : variable_block_partition(coll, seq, norm_lens, lambda));
+                    auto t = ((type == partition_type::fixed_blocks) ? static_block_partition(seq, norm_lens, boost::get<uint64_t>(block_size))
+                                                      : variable_block_partition(coll, seq, norm_lens, boost::get<float>(block_size)));
 
                     auto ind = compressor_builder.compress_data(t.second);
 

--- a/include/pisa/wand_data_compressed.hpp
+++ b/include/pisa/wand_data_compressed.hpp
@@ -109,7 +109,7 @@ class wand_data_compressed {
             if (seq.docs.size() > configuration::get().threshold_wand_list) {
 
                 auto t =
-                    (block_size.type() == typeid(FixedBlock))
+                    block_size.type() == typeid(FixedBlock)
                         ? static_block_partition(
                               seq, norm_lens, boost::get<FixedBlock>(block_size).size)
                         : variable_block_partition(

--- a/include/pisa/wand_data_compressed.hpp
+++ b/include/pisa/wand_data_compressed.hpp
@@ -112,7 +112,7 @@ namespace {
                 spdlog::info("Storing max weight for each list and for each block...");
             }
 
-            float add_sequence(binary_freq_collection::sequence const &seq, binary_freq_collection const &coll, std::vector<float> const & norm_lens, boost::variant<float, uint64_t> block_size = uint64_t(0)){
+            float add_sequence(binary_freq_collection::sequence const &seq, binary_freq_collection const &coll, std::vector<float> const & norm_lens, boost::variant<float, uint64_t> block_size) {
 
                 if (seq.docs.size() > configuration::get().threshold_wand_list) {
 

--- a/include/pisa/wand_data_compressed.hpp
+++ b/include/pisa/wand_data_compressed.hpp
@@ -10,230 +10,205 @@
 #include "scorer/bm25.hpp"
 #include "util/util.hpp"
 
+#include "global_parameters.hpp"
 #include "sequence/positive_sequence.hpp"
 #include "util/index_build_utils.hpp"
 #include "wand_utils.hpp"
-#include "global_parameters.hpp"
-
 
 namespace pisa {
 namespace {
     static const size_t score_bits_size = broadword::msb(configuration::get().reference_size);
 }
 
-    class uniform_score_compressor{
+class uniform_score_compressor {
 
-    public:
-        class builder{
-        public:
-            builder(uint64_t num_docs, global_parameters const& params)
-                : m_params(params)
-                , m_num_docs((num_docs+1) << score_bits_size)
-                , m_docs_sequences(params)
-            {}
-
-            std::vector<uint32_t> compress_data(std::vector<float> effective_scores){
-                float quant = 1.f/configuration::get().reference_size;
-
-                //Partition scores.
-                std::vector<uint32_t> score_indexes;
-                score_indexes.reserve(effective_scores.size());
-                for(const auto& score: effective_scores) {
-                    size_t pos = 1;
-                    while (score > quant*pos)
-                        pos++;
-                    score_indexes.push_back(pos-1);
-
-                }
-                return score_indexes;
-            }
-
-            template <typename Sequence = compact_elias_fano, typename DocsIterator>
-            void add_posting_list(uint64_t n, DocsIterator docs_begin, DocsIterator score_begin)
-            {
-                std::vector<uint64_t> temp;
-                for(size_t i =0; i < n; ++i)
-                {
-                    uint64_t elem = *(docs_begin + i);
-                    elem = elem << score_bits_size;
-                    elem += *(score_begin + i);
-                    temp.push_back(elem);
-                }
-
-                if (!n) throw std::invalid_argument("List must be nonempty");
-                bit_vector_builder docs_bits;
-                write_gamma_nonzero(docs_bits, n);
-                Sequence::write(docs_bits, temp.begin(),
-                                m_num_docs, n,
-                                m_params);
-                m_docs_sequences.append(docs_bits);
-            }
-
-            void build(bitvector_collection& docs_sequences){
-                m_docs_sequences.build(docs_sequences);
-            }
-
-        global_parameters params() {
-            return m_params;
-        }
-
-        uint64_t num_docs() {
-            return m_num_docs;
-        }
-
-        private:
-            global_parameters m_params;
-            uint64_t m_num_docs;
-            bitvector_collection::builder m_docs_sequences;
-
-
-        };
-
-        static float inline score(uint32_t index){
-                const float quant = 1.f/configuration::get().reference_size;
-                return quant * (index + 1);
-        }
-
-    };
-
-    template<typename Scorer = bm25, typename score_compressor = uniform_score_compressor>
-    class wand_data_compressed {
-    public:
-        class builder{
-           public:
-            builder(partition_type                type,
-                    binary_freq_collection const &coll,
-                    global_parameters const &     params)
-                : total_elements(0),
-                  total_blocks(0),
-                  type(type),
-                  params(params),
-                  compressor_builder(coll.num_docs(), params) {
-                spdlog::info("Storing max weight for each list and for each block...");
-            }
-
-            float add_sequence(binary_freq_collection::sequence const &seq, binary_freq_collection const &coll, std::vector<float> const & norm_lens, boost::variant<float, uint64_t> block_size) {
-
-                if (seq.docs.size() > configuration::get().threshold_wand_list) {
-
-                    auto t = ((type == partition_type::fixed_blocks) ? static_block_partition(seq, norm_lens, boost::get<uint64_t>(block_size))
-                                                      : variable_block_partition(coll, seq, norm_lens, boost::get<float>(block_size)));
-
-                    auto ind = compressor_builder.compress_data(t.second);
-
-                    compressor_builder.add_posting_list(t.first.size(), t.first.begin(),
-                                                           ind.begin());
-
-                    max_term_weight.push_back(*(std::max_element(t.second.begin(), t.second.end())));
-                    total_elements += seq.docs.size();
-                    total_blocks += t.first.size();
-                } else {
-                    max_term_weight.push_back(0.0f);
-                    std::vector<uint32_t> temp = {0};
-                    compressor_builder.add_posting_list(temp.size(), temp.begin(),
-                                                           temp.begin());
-                }
-
-                return max_term_weight.back();
-
-            }
-
-            void build(wand_data_compressed &wdata) {
-                wdata.m_num_docs = compressor_builder.num_docs();
-                wdata.m_params = compressor_builder.params();
-                compressor_builder.build(wdata.m_docs_sequences);
-                spdlog::info("number of elements / number of blocks: {}",
-                             (float)total_elements / (float)total_blocks);
-            }
-
-            uint64_t total_elements;
-            uint64_t total_blocks;
-            partition_type type;
-            std::vector<float> score_references;
-            std::vector<float> max_term_weight;
-            global_parameters const &params;
-            typename score_compressor::builder compressor_builder;
-        };
-
-        class enumerator{
-            friend class wand_data_compressed;
-        public:
-            enumerator(compact_elias_fano::enumerator docs_enum)
-                : m_docs_enum(docs_enum)
-            {
-                reset();
-            }
-
-            void reset()
-            {
-                uint64_t val = m_docs_enum.move(0).second;
-                m_cur_docid = val >> score_bits_size;
-                uint64_t mask = configuration::get().reference_size - 1;
-		m_cur_score_index = (val & mask);
-            }
-
-            void PISA_FLATTEN_FUNC next_geq(uint64_t lower_bound) {
-                if(docid() != lower_bound) {
-                    lower_bound = lower_bound << score_bits_size;
-                    auto val = m_docs_enum.next_geq(lower_bound);
-                    m_cur_docid = val.second >> score_bits_size;
-		    uint64_t mask = configuration::get().reference_size - 1;
-                    m_cur_score_index = (val.second & mask);
-                }
-            }
-
-            float PISA_FLATTEN_FUNC score()  {
-                return score_compressor::score(m_cur_score_index);
-            }
-
-            uint64_t PISA_FLATTEN_FUNC docid() const {
-                return m_cur_docid;
-            }
-
-        private:
-            uint64_t m_cur_docid;
-            uint64_t m_cur_score_index;
-            compact_elias_fano::enumerator m_docs_enum;
-        };
-
-        uint64_t size() const
+   public:
+    class builder {
+       public:
+        builder(uint64_t num_docs, global_parameters const &params)
+            : m_params(params),
+              m_num_docs((num_docs + 1) << score_bits_size),
+              m_docs_sequences(params)
         {
-            return m_docs_sequences.size();
         }
 
-        uint64_t num_docs() const
+        std::vector<uint32_t> compress_data(std::vector<float> effective_scores)
         {
-            return m_num_docs;
+            float quant = 1.f / configuration::get().reference_size;
+
+            // Partition scores.
+            std::vector<uint32_t> score_indexes;
+            score_indexes.reserve(effective_scores.size());
+            for (const auto &score : effective_scores) {
+                size_t pos = 1;
+                while (score > quant * pos)
+                    pos++;
+                score_indexes.push_back(pos - 1);
+            }
+            return score_indexes;
         }
 
-        enumerator get_enum(size_t i) const
+        template <typename Sequence = compact_elias_fano, typename DocsIterator>
+        void add_posting_list(uint64_t n, DocsIterator docs_begin, DocsIterator score_begin)
         {
-            assert(i < size());
-            auto docs_it = m_docs_sequences.get(m_params, i);
+            std::vector<uint64_t> temp;
+            for (size_t i = 0; i < n; ++i) {
+                uint64_t elem = *(docs_begin + i);
+                elem = elem << score_bits_size;
+                elem += *(score_begin + i);
+                temp.push_back(elem);
+            }
 
-            uint64_t n = read_gamma_nonzero(docs_it);
-            typename compact_elias_fano::enumerator docs_enum(m_docs_sequences.bits(),
-                                                        docs_it.position(),
-                                                        num_docs(), n,
-                                                        m_params);
-
-            return enumerator(docs_enum);
+            if (!n)
+                throw std::invalid_argument("List must be nonempty");
+            bit_vector_builder docs_bits;
+            write_gamma_nonzero(docs_bits, n);
+            Sequence::write(docs_bits, temp.begin(), m_num_docs, n, m_params);
+            m_docs_sequences.append(docs_bits);
         }
 
+        void build(bitvector_collection &docs_sequences) { m_docs_sequences.build(docs_sequences); }
 
-        template<typename Visitor>
-        void map(Visitor& visit)
-        {
-            visit
-                (m_params, "m_params")
-                (m_num_docs, "m_num_docs")
-                (m_docs_sequences, "m_docs_sequences");
-        }
+        global_parameters params() { return m_params; }
 
-    private:
+        uint64_t num_docs() { return m_num_docs; }
+
+       private:
         global_parameters m_params;
         uint64_t m_num_docs;
-        bitvector_collection m_docs_sequences;
+        bitvector_collection::builder m_docs_sequences;
     };
 
-}
+    static float inline score(uint32_t index)
+    {
+        const float quant = 1.f / configuration::get().reference_size;
+        return quant * (index + 1);
+    }
+};
+
+template <typename Scorer = bm25, typename score_compressor = uniform_score_compressor>
+class wand_data_compressed {
+   public:
+    class builder {
+       public:
+        builder(binary_freq_collection const &coll, global_parameters const &params)
+            : total_elements(0),
+              total_blocks(0),
+              params(params),
+              compressor_builder(coll.num_docs(), params)
+        {
+            spdlog::info("Storing max weight for each list and for each block...");
+        }
+
+        float add_sequence(binary_freq_collection::sequence const &seq,
+                           binary_freq_collection const &coll,
+                           std::vector<float> const &norm_lens,
+                           BlockSize block_size)
+        {
+
+            if (seq.docs.size() > configuration::get().threshold_wand_list) {
+
+                auto t =
+                    (block_size.type() == typeid(FixedBlock))
+                        ? static_block_partition(
+                              seq, norm_lens, boost::get<FixedBlock>(block_size).size)
+                        : variable_block_partition(
+                              coll, seq, norm_lens, boost::get<VariableBlock>(block_size).lambda);
+
+                auto ind = compressor_builder.compress_data(t.second);
+
+                compressor_builder.add_posting_list(t.first.size(), t.first.begin(), ind.begin());
+
+                max_term_weight.push_back(*(std::max_element(t.second.begin(), t.second.end())));
+                total_elements += seq.docs.size();
+                total_blocks += t.first.size();
+            } else {
+                max_term_weight.push_back(0.0f);
+                std::vector<uint32_t> temp = {0};
+                compressor_builder.add_posting_list(temp.size(), temp.begin(), temp.begin());
+            }
+
+            return max_term_weight.back();
+        }
+
+        void build(wand_data_compressed &wdata)
+        {
+            wdata.m_num_docs = compressor_builder.num_docs();
+            wdata.m_params = compressor_builder.params();
+            compressor_builder.build(wdata.m_docs_sequences);
+            spdlog::info("number of elements / number of blocks: {}",
+                         (float)total_elements / (float)total_blocks);
+        }
+
+        uint64_t total_elements;
+        uint64_t total_blocks;
+        std::vector<float> score_references;
+        std::vector<float> max_term_weight;
+        global_parameters const &params;
+        typename score_compressor::builder compressor_builder;
+    };
+
+    class enumerator {
+        friend class wand_data_compressed;
+
+       public:
+        enumerator(compact_elias_fano::enumerator docs_enum) : m_docs_enum(docs_enum) { reset(); }
+
+        void reset()
+        {
+            uint64_t val = m_docs_enum.move(0).second;
+            m_cur_docid = val >> score_bits_size;
+            uint64_t mask = configuration::get().reference_size - 1;
+            m_cur_score_index = (val & mask);
+        }
+
+        void PISA_FLATTEN_FUNC next_geq(uint64_t lower_bound)
+        {
+            if (docid() != lower_bound) {
+                lower_bound = lower_bound << score_bits_size;
+                auto val = m_docs_enum.next_geq(lower_bound);
+                m_cur_docid = val.second >> score_bits_size;
+                uint64_t mask = configuration::get().reference_size - 1;
+                m_cur_score_index = (val.second & mask);
+            }
+        }
+
+        float PISA_FLATTEN_FUNC score() { return score_compressor::score(m_cur_score_index); }
+
+        uint64_t PISA_FLATTEN_FUNC docid() const { return m_cur_docid; }
+
+       private:
+        uint64_t m_cur_docid;
+        uint64_t m_cur_score_index;
+        compact_elias_fano::enumerator m_docs_enum;
+    };
+
+    uint64_t size() const { return m_docs_sequences.size(); }
+
+    uint64_t num_docs() const { return m_num_docs; }
+
+    enumerator get_enum(size_t i) const
+    {
+        assert(i < size());
+        auto docs_it = m_docs_sequences.get(m_params, i);
+
+        uint64_t n = read_gamma_nonzero(docs_it);
+        typename compact_elias_fano::enumerator docs_enum(
+            m_docs_sequences.bits(), docs_it.position(), num_docs(), n, m_params);
+
+        return enumerator(docs_enum);
+    }
+
+    template <typename Visitor>
+    void map(Visitor &visit)
+    {
+        visit(m_params, "m_params")(m_num_docs, "m_num_docs")(m_docs_sequences, "m_docs_sequences");
+    }
+
+   private:
+    global_parameters m_params;
+    uint64_t m_num_docs;
+    bitvector_collection m_docs_sequences;
+};
+
+} // namespace pisa

--- a/include/pisa/wand_data_range.hpp
+++ b/include/pisa/wand_data_range.hpp
@@ -60,7 +60,7 @@ class wand_data_range {
         float add_sequence(binary_freq_collection::sequence const &term_seq,
                            binary_freq_collection const &coll,
                            std::vector<float> const &norm_lens,
-                           [[maybe_unused]] float lambda)
+                           [[maybe_unused]] boost::variant<float, uint64_t> block_size = uint64_t(0))
         {
             float max_score = 0.0f;
 

--- a/include/pisa/wand_data_range.hpp
+++ b/include/pisa/wand_data_range.hpp
@@ -60,7 +60,7 @@ class wand_data_range {
         float add_sequence(binary_freq_collection::sequence const &term_seq,
                            binary_freq_collection const &coll,
                            std::vector<float> const &norm_lens,
-                           [[maybe_unused]] boost::variant<float, uint64_t> block_size = uint64_t(0))
+                           [[maybe_unused]] boost::variant<float, uint64_t> block_size)
         {
             float max_score = 0.0f;
 

--- a/include/pisa/wand_data_range.hpp
+++ b/include/pisa/wand_data_range.hpp
@@ -29,7 +29,7 @@ class wand_data_range {
     {
         std::vector<float> block_max_scores(m_blocks_num, 0.0f);
         for_each_posting(list, [&](auto docid, auto freq) {
-            float& current_max = block_max_scores[docid / range_size];
+            float &current_max = block_max_scores[docid / range_size];
             current_max = std::max(current_max, scorer(docid, freq));
         });
         return block_max_scores;
@@ -37,11 +37,9 @@ class wand_data_range {
 
     class builder {
        public:
-        builder(partition_type type,
-                binary_freq_collection const &coll,
+        builder(binary_freq_collection const &coll,
                 [[maybe_unused]] global_parameters const &params)
             : blocks_num(ceil_div(coll.num_docs(), range_size)),
-              type(type),
               total_elements(0),
               blocks_start{0},
               block_max_term_weight{}
@@ -60,7 +58,7 @@ class wand_data_range {
         float add_sequence(binary_freq_collection::sequence const &term_seq,
                            binary_freq_collection const &coll,
                            std::vector<float> const &norm_lens,
-                           [[maybe_unused]] boost::variant<float, uint64_t> block_size)
+                           [[maybe_unused]] BlockSize block_size)
         {
             float max_score = 0.0f;
 
@@ -95,7 +93,6 @@ class wand_data_range {
         }
 
         uint64_t blocks_num;
-        partition_type type;
         uint64_t total_elements;
         std::vector<uint64_t> blocks_start;
         std::vector<float> block_max_term_weight;
@@ -108,7 +105,8 @@ class wand_data_range {
         enumerator(uint32_t _block_start,
                    mapper::mappable_vector<float> const &block_max_term_weight)
             : cur_pos(0), block_start(_block_start), m_block_max_term_weight(block_max_term_weight)
-        {}
+        {
+        }
 
         void PISA_NOINLINE next_block() { cur_pos += 1; }
         void PISA_NOINLINE next_geq(uint64_t lower_bound) { cur_pos = lower_bound / range_size; }

--- a/include/pisa/wand_data_raw.hpp
+++ b/include/pisa/wand_data_raw.hpp
@@ -40,7 +40,7 @@ class wand_data_raw {
             if (seq.docs.size() > configuration::get().threshold_wand_list) {
 
                 auto t =
-                    (block_size.type() == typeid(FixedBlock))
+                    block_size.type() == typeid(FixedBlock)
                         ? static_block_partition(
                               seq, norm_lens, boost::get<FixedBlock>(block_size).size)
                         : variable_block_partition(

--- a/include/pisa/wand_data_raw.hpp
+++ b/include/pisa/wand_data_raw.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "boost/variant.hpp"
 #include "spdlog/spdlog.h"
 
 #include "mappable/mappable_vector.hpp"
@@ -33,12 +34,12 @@ namespace pisa {
                 blocks_start.push_back(0);
             }
 
-            float add_sequence(binary_freq_collection::sequence const &seq, binary_freq_collection const &coll, std::vector<float> const & norm_lens, const float lambda = 0.0f){
+            float add_sequence(binary_freq_collection::sequence const &seq, binary_freq_collection const &coll, std::vector<float> const & norm_lens, boost::variant<float, uint64_t> block_size = uint64_t(0)){
 
                 if (seq.docs.size() > configuration::get().threshold_wand_list) {
 
-                    auto t = ((type == partition_type::fixed_blocks) ? static_block_partition(seq, norm_lens)
-                                                      : variable_block_partition(coll, seq, norm_lens, lambda));
+                    auto t = ((type == partition_type::fixed_blocks) ? static_block_partition(seq, norm_lens, boost::get<uint64_t>(block_size))
+                                                      : variable_block_partition(coll, seq, norm_lens, boost::get<float>(block_size)));
 
                     block_max_term_weight.insert(block_max_term_weight.end(), t.second.begin(),
                                                  t.second.end());

--- a/include/pisa/wand_data_raw.hpp
+++ b/include/pisa/wand_data_raw.hpp
@@ -6,139 +6,140 @@
 #include "mappable/mappable_vector.hpp"
 
 #include "binary_freq_collection.hpp"
-#include "scorer/bm25.hpp"
-#include "wand_utils.hpp"
 #include "global_parameters.hpp"
+#include "scorer/bm25.hpp"
 #include "util/compiler_attribute.hpp"
+#include "wand_utils.hpp"
 
 namespace pisa {
 
-    template<typename Scorer = bm25>
-    class wand_data_raw {
-    public:
-        wand_data_raw() { }
+template <typename Scorer = bm25>
+class wand_data_raw {
+   public:
+    wand_data_raw() {}
 
-        class builder{
-           public:
-            builder(partition_type                type,
-                    binary_freq_collection const &coll,
-                    global_parameters const &     params)
-            {
-                (void) coll;
-                (void) params;
-                this->type = type;
-                spdlog::info("Storing max weight for each list and for each block...");
-                total_elements = 0;
-                total_blocks = 0;
-                effective_list = 0;
-                blocks_start.push_back(0);
-            }
-
-            float add_sequence(binary_freq_collection::sequence const &seq, binary_freq_collection const &coll, std::vector<float> const & norm_lens, boost::variant<float, uint64_t> block_size){
-
-                if (seq.docs.size() > configuration::get().threshold_wand_list) {
-
-                    auto t = ((type == partition_type::fixed_blocks) ? static_block_partition(seq, norm_lens, boost::get<uint64_t>(block_size))
-                                                      : variable_block_partition(coll, seq, norm_lens, boost::get<float>(block_size)));
-
-                    block_max_term_weight.insert(block_max_term_weight.end(), t.second.begin(),
-                                                 t.second.end());
-                    block_docid.insert(block_docid.end(), t.first.begin(), t.first.end());
-                    max_term_weight.push_back(*(std::max_element(t.second.begin(), t.second.end())));
-                    blocks_start.push_back(t.first.size() + blocks_start.back());
-
-                    total_elements += seq.docs.size();
-                    total_blocks += t.first.size();
-                    effective_list++;
-                } else {
-                    max_term_weight.push_back(0.0f);
-                    blocks_start.push_back(blocks_start.back());
-                }
-
-                return max_term_weight.back();
-
-            }
-
-            void build(wand_data_raw &wdata) {
-                wdata.m_block_max_term_weight.steal(block_max_term_weight);
-                wdata.m_blocks_start.steal(blocks_start);
-                wdata.m_block_docid.steal(block_docid);
-                spdlog::info("number of elements / number of blocks: {}",
-                             static_cast<float>(total_elements) / static_cast<float>(total_blocks));
-            }
-
-            partition_type type;
-            uint64_t total_elements;
-            uint64_t total_blocks;
-            uint64_t effective_list;
-            std::vector<float> max_term_weight;
-            std::vector<uint64_t> blocks_start;
-            std::vector<float> block_max_term_weight;
-            std::vector<uint32_t> block_docid;
-        };
-        class enumerator{
-            friend class wand_data_raw;
-        public:
-
-            enumerator(uint32_t _block_start, uint32_t _block_number, mapper::mappable_vector<float> const & max_term_weight,
-            mapper::mappable_vector<uint32_t> const & block_docid) :
-                    cur_pos(0),
-                    block_start(_block_start),
-                    block_number(_block_number),
-                    m_block_max_term_weight(max_term_weight),
-                    m_block_docid(block_docid)
-                        {}
-
-
-            void PISA_NOINLINE next_geq(uint64_t lower_bound) {
-                while (cur_pos + 1 < block_number &&
-                        m_block_docid[block_start + cur_pos] <
-                       lower_bound) {
-                    cur_pos++;
-                }
-            }
-
-
-            float PISA_FLATTEN_FUNC score() const {
-                return m_block_max_term_weight[block_start + cur_pos];
-            }
-
-            uint64_t PISA_FLATTEN_FUNC docid() const {
-                return m_block_docid[block_start + cur_pos];
-            }
-
-
-            uint64_t PISA_FLATTEN_FUNC find_next_skip() {
-                return m_block_docid[cur_pos + block_start];
-            }
-
-        private:
-            uint64_t cur_pos;
-            uint64_t block_start;
-            uint64_t block_number;
-            mapper::mappable_vector<float> const &m_block_max_term_weight;
-            mapper::mappable_vector<uint32_t> const &m_block_docid;
-
-        };
-
-        enumerator get_enum(uint32_t i) const {
-            return enumerator(m_blocks_start[i], m_blocks_start[i+1] - m_blocks_start[i], m_block_max_term_weight, m_block_docid);
+    class builder {
+       public:
+        builder(binary_freq_collection const &coll, global_parameters const &params)
+        {
+            (void)coll;
+            (void)params;
+            spdlog::info("Storing max weight for each list and for each block...");
+            total_elements = 0;
+            total_blocks = 0;
+            effective_list = 0;
+            blocks_start.push_back(0);
         }
 
-        template<typename Visitor>
-        void map(Visitor &visit) {
-            visit
-                    (m_blocks_start, "m_blocks_start")
-                    (m_block_max_term_weight, "m_block_max_term_weight")
-                    (m_block_docid, "m_block_docid");
+        float add_sequence(binary_freq_collection::sequence const &seq,
+                           binary_freq_collection const &coll,
+                           std::vector<float> const &norm_lens,
+                           BlockSize block_size)
+        {
+
+            if (seq.docs.size() > configuration::get().threshold_wand_list) {
+
+                auto t =
+                    (block_size.type() == typeid(FixedBlock))
+                        ? static_block_partition(
+                              seq, norm_lens, boost::get<FixedBlock>(block_size).size)
+                        : variable_block_partition(
+                              coll, seq, norm_lens, boost::get<VariableBlock>(block_size).lambda);
+
+                block_max_term_weight.insert(
+                    block_max_term_weight.end(), t.second.begin(), t.second.end());
+                block_docid.insert(block_docid.end(), t.first.begin(), t.first.end());
+                max_term_weight.push_back(*(std::max_element(t.second.begin(), t.second.end())));
+                blocks_start.push_back(t.first.size() + blocks_start.back());
+
+                total_elements += seq.docs.size();
+                total_blocks += t.first.size();
+                effective_list++;
+            } else {
+                max_term_weight.push_back(0.0f);
+                blocks_start.push_back(blocks_start.back());
+            }
+
+            return max_term_weight.back();
         }
 
-    private:
+        void build(wand_data_raw &wdata)
+        {
+            wdata.m_block_max_term_weight.steal(block_max_term_weight);
+            wdata.m_blocks_start.steal(blocks_start);
+            wdata.m_block_docid.steal(block_docid);
+            spdlog::info("number of elements / number of blocks: {}",
+                         static_cast<float>(total_elements) / static_cast<float>(total_blocks));
+        }
 
-        mapper::mappable_vector<uint64_t> m_blocks_start;
-        mapper::mappable_vector<float> m_block_max_term_weight;
-        mapper::mappable_vector<uint32_t> m_block_docid;
+        uint64_t total_elements;
+        uint64_t total_blocks;
+        uint64_t effective_list;
+        std::vector<float> max_term_weight;
+        std::vector<uint64_t> blocks_start;
+        std::vector<float> block_max_term_weight;
+        std::vector<uint32_t> block_docid;
+    };
+    class enumerator {
+        friend class wand_data_raw;
 
+       public:
+        enumerator(uint32_t _block_start,
+                   uint32_t _block_number,
+                   mapper::mappable_vector<float> const &max_term_weight,
+                   mapper::mappable_vector<uint32_t> const &block_docid)
+            : cur_pos(0),
+              block_start(_block_start),
+              block_number(_block_number),
+              m_block_max_term_weight(max_term_weight),
+              m_block_docid(block_docid)
+        {
+        }
+
+        void PISA_NOINLINE next_geq(uint64_t lower_bound)
+        {
+            while (cur_pos + 1 < block_number &&
+                   m_block_docid[block_start + cur_pos] < lower_bound) {
+                cur_pos++;
+            }
+        }
+
+        float PISA_FLATTEN_FUNC score() const
+        {
+            return m_block_max_term_weight[block_start + cur_pos];
+        }
+
+        uint64_t PISA_FLATTEN_FUNC docid() const { return m_block_docid[block_start + cur_pos]; }
+
+        uint64_t PISA_FLATTEN_FUNC find_next_skip() { return m_block_docid[cur_pos + block_start]; }
+
+       private:
+        uint64_t cur_pos;
+        uint64_t block_start;
+        uint64_t block_number;
+        mapper::mappable_vector<float> const &m_block_max_term_weight;
+        mapper::mappable_vector<uint32_t> const &m_block_docid;
     };
 
-}
+    enumerator get_enum(uint32_t i) const
+    {
+        return enumerator(m_blocks_start[i],
+                          m_blocks_start[i + 1] - m_blocks_start[i],
+                          m_block_max_term_weight,
+                          m_block_docid);
+    }
+
+    template <typename Visitor>
+    void map(Visitor &visit)
+    {
+        visit(m_blocks_start, "m_blocks_start")(m_block_max_term_weight, "m_block_max_term_weight")(
+            m_block_docid, "m_block_docid");
+    }
+
+   private:
+    mapper::mappable_vector<uint64_t> m_blocks_start;
+    mapper::mappable_vector<float> m_block_max_term_weight;
+    mapper::mappable_vector<uint32_t> m_block_docid;
+};
+
+} // namespace pisa

--- a/include/pisa/wand_data_raw.hpp
+++ b/include/pisa/wand_data_raw.hpp
@@ -34,7 +34,7 @@ namespace pisa {
                 blocks_start.push_back(0);
             }
 
-            float add_sequence(binary_freq_collection::sequence const &seq, binary_freq_collection const &coll, std::vector<float> const & norm_lens, boost::variant<float, uint64_t> block_size = uint64_t(0)){
+            float add_sequence(binary_freq_collection::sequence const &seq, binary_freq_collection const &coll, std::vector<float> const & norm_lens, boost::variant<float, uint64_t> block_size){
 
                 if (seq.docs.size() > configuration::get().threshold_wand_list) {
 

--- a/include/pisa/wand_utils.hpp
+++ b/include/pisa/wand_utils.hpp
@@ -11,10 +11,13 @@ enum class partition_type { fixed_blocks, variable_blocks };
 template <typename Scorer = bm25>
 std::pair<std::vector<uint32_t>, std::vector<float>>
 static_block_partition(binary_freq_collection::sequence const &seq,
-                       std::vector<float> const &norm_lens) {
+                       std::vector<float> const &norm_lens,
+                       const uint64_t in_block_size = 0) {
   std::vector<uint32_t> block_docid;
   std::vector<float> block_max_term_weight;
   uint64_t block_size = configuration::get().block_size;
+  if (in_block_size > 0)
+      block_size = in_block_size;
 
   // Auxiliary vector
   float max_score = 0;

--- a/include/pisa/wand_utils.hpp
+++ b/include/pisa/wand_utils.hpp
@@ -1,82 +1,88 @@
 #pragma once
 
-#include "configuration.hpp"
 #include "binary_freq_collection.hpp"
+#include "configuration.hpp"
 #include "score_opt_partition.hpp"
 
 namespace pisa {
 
-enum class partition_type { fixed_blocks, variable_blocks };
+struct FixedBlock {
+    uint64_t size;
+    FixedBlock() : size(configuration::get().block_size) {}
+    FixedBlock(const uint64_t in_size) : size(in_size) {}
+};
+
+struct VariableBlock {
+    float lambda;
+    VariableBlock() : lambda(configuration::get().fixed_cost_wand_partition) {}
+    VariableBlock(const float in_lambda) : lambda(in_lambda) {}
+};
+
+using BlockSize = boost::variant<FixedBlock, VariableBlock>;
 
 template <typename Scorer = bm25>
-std::pair<std::vector<uint32_t>, std::vector<float>>
-static_block_partition(binary_freq_collection::sequence const &seq,
-                       std::vector<float> const &norm_lens,
-                       const uint64_t in_block_size = 0) {
-  std::vector<uint32_t> block_docid;
-  std::vector<float> block_max_term_weight;
-  uint64_t block_size = configuration::get().block_size;
-  if (in_block_size > 0)
-      block_size = in_block_size;
+std::pair<std::vector<uint32_t>, std::vector<float>> static_block_partition(
+    binary_freq_collection::sequence const &seq,
+    std::vector<float> const &norm_lens,
+    const uint64_t block_size)
+{
+    std::vector<uint32_t> block_docid;
+    std::vector<float> block_max_term_weight;
 
-  // Auxiliary vector
-  float max_score = 0;
-  float block_max_score = 0;
-  size_t current_block = 0;
-  size_t i;
+    // Auxiliary vector
+    float max_score = 0;
+    float block_max_score = 0;
+    size_t current_block = 0;
+    size_t i;
 
-  for (i = 0; i < seq.docs.size(); ++i) {
-    uint64_t docid = *(seq.docs.begin() + i);
-    uint64_t freq = *(seq.freqs.begin() + i);
-    float score = Scorer::doc_term_weight(freq, norm_lens[docid]);
-    max_score = std::max(max_score, score);
-    if (i == 0 || (i / block_size) == current_block) {
-      block_max_score = std::max(block_max_score, score);
-    } else {
-      block_docid.push_back(*(seq.docs.begin() + i) - 1);
-      block_max_term_weight.push_back(block_max_score);
-      current_block++;
-      block_max_score = std::max((float)0, score);
+    for (i = 0; i < seq.docs.size(); ++i) {
+        uint64_t docid = *(seq.docs.begin() + i);
+        uint64_t freq = *(seq.freqs.begin() + i);
+        float score = Scorer::doc_term_weight(freq, norm_lens[docid]);
+        max_score = std::max(max_score, score);
+        if (i == 0 || (i / block_size) == current_block) {
+            block_max_score = std::max(block_max_score, score);
+        } else {
+            block_docid.push_back(*(seq.docs.begin() + i) - 1);
+            block_max_term_weight.push_back(block_max_score);
+            current_block++;
+            block_max_score = std::max((float)0, score);
+        }
     }
-  }
-  block_docid.push_back(*(seq.docs.begin() + seq.docs.size() - 1));
-  block_max_term_weight.push_back(block_max_score);
+    block_docid.push_back(*(seq.docs.begin() + seq.docs.size() - 1));
+    block_max_term_weight.push_back(block_max_score);
 
-  return std::make_pair(block_docid, block_max_term_weight);
+    return std::make_pair(block_docid, block_max_term_weight);
 }
 
 template <typename Scorer = bm25>
-std::pair<std::vector<uint32_t>, std::vector<float>>
-variable_block_partition(binary_freq_collection const &coll,
-                         binary_freq_collection::sequence const &seq,
-                         std::vector<float> const &norm_lens,
-                         const float lambda = 0.0f) {
+std::pair<std::vector<uint32_t>, std::vector<float>> variable_block_partition(
+    binary_freq_collection const &coll,
+    binary_freq_collection::sequence const &seq,
+    std::vector<float> const &norm_lens,
+    const float lambda)
+{
 
-  auto eps1 = configuration::get().eps1_wand;
-  auto eps2 = configuration::get().eps2_wand;
-  auto fixed_cost = configuration::get().fixed_cost_wand_partition;
-  // Use input param
-  if (lambda != 0.0f)
-      fixed_cost = lambda;
+    auto eps1 = configuration::get().eps1_wand;
+    auto eps2 = configuration::get().eps2_wand;
 
-  // Auxiliary vector
-  using doc_score_t = std::pair<uint64_t, float>;
-  std::vector<doc_score_t> doc_score;
+    // Auxiliary vector
+    using doc_score_t = std::pair<uint64_t, float>;
+    std::vector<doc_score_t> doc_score;
 
-  std::transform(seq.docs.begin(),
+    std::transform(seq.docs.begin(),
                    seq.docs.end(),
                    seq.freqs.begin(),
                    std::back_inserter(doc_score),
                    [&](const uint64_t &doc, const uint64_t &freq) -> doc_score_t {
-                     return {doc, Scorer::doc_term_weight(freq, norm_lens[doc])};
+                       return {doc, Scorer::doc_term_weight(freq, norm_lens[doc])};
                    });
 
-  float estimated_idf =
-      Scorer::query_term_weight(1, seq.docs.size(), coll.num_docs());
-  auto p = score_opt_partition(doc_score.begin(), 0, doc_score.size(),
-                               eps1, eps2, fixed_cost, estimated_idf);
+    float estimated_idf = Scorer::query_term_weight(1, seq.docs.size(), coll.num_docs());
+    auto p = score_opt_partition(
+        doc_score.begin(), 0, doc_score.size(), eps1, eps2, lambda, estimated_idf);
 
-  return std::make_pair(p.docids, p.max_values);
+    return std::make_pair(p.docids, p.max_values);
 }
 
-}  // namespace pisa
+} // namespace pisa

--- a/include/pisa/wand_utils.hpp
+++ b/include/pisa/wand_utils.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "boost/variant.hpp"
+
 #include "binary_freq_collection.hpp"
 #include "configuration.hpp"
 #include "score_opt_partition.hpp"

--- a/src/create_wand_data.cpp
+++ b/src/create_wand_data.cpp
@@ -48,7 +48,13 @@ int main(int argc, const char **argv)
     binary_collection sizes_coll((input_basename + ".sizes").c_str());
     binary_freq_collection coll(input_basename.c_str());
 
+    // Initialize the variant to the correct type
     boost::variant<float, uint64_t> block_size = uint64_t(0);
+    if (variable_block) {
+        block_size = 0.0f;
+    }
+
+    // Set block size based on configuration
     if (lambda != 0.0f && variable_block) {
         block_size = lambda;
     } else if (lambda != 0.0f && !variable_block) {

--- a/src/create_wand_data.cpp
+++ b/src/create_wand_data.cpp
@@ -31,7 +31,7 @@ int main(int argc, const char **argv)
     app.add_option("-c,--collection", input_basename, "Collection basename")->required();
     app.add_option("-o,--output", output_filename, "Output filename")->required();
     auto var_block_opt = app.add_flag("--variable-block", variable_block, "Variable length blocks");
-    auto var_block_param_opt = app.add_option("-b,--block", fixed_block_size, "Block size for fixed-length blocks")->excludes(var_block_opt);
+    auto var_block_param_opt = app.add_option("-b,--block-size", fixed_block_size, "Block size for fixed-length blocks")->excludes(var_block_opt);
     app.add_option("-l,--lambda", lambda, "Lambda parameter for variable blocks")->excludes(var_block_param_opt);
     app.add_flag("--compress", compress, "Compress additional data");
     app.add_flag("--range", range, "Create docid-range based data")->excludes(var_block_opt);

--- a/src/create_wand_data.cpp
+++ b/src/create_wand_data.cpp
@@ -1,6 +1,7 @@
 #include <fstream>
 #include <iostream>
 
+#include "boost/variant.hpp"
 #include "spdlog/spdlog.h"
 
 #include "binary_collection.hpp"
@@ -9,30 +10,32 @@
 #include "util/util.hpp"
 #include "wand_data.hpp"
 #include "wand_data_compressed.hpp"
-#include "wand_data_raw.hpp"
 #include "wand_data_range.hpp"
+#include "wand_data_raw.hpp"
 
 #include "CLI/CLI.hpp"
 
-int main(int argc, const char **argv) {
+int main(int argc, const char **argv)
+{
     using namespace pisa;
 
     float lambda = 0.0f;
+    uint64_t fixed_block_size = 0;
     std::string input_basename;
     std::string output_filename;
-    bool        variable_block = false;
-    bool        compress       = false;
-    bool        range          = false;
+    bool variable_block = false;
+    bool compress = false;
+    bool range = false;
 
     CLI::App app{"create_wand_data - a tool for creating additional data for query processing."};
     app.add_option("-c,--collection", input_basename, "Collection basename")->required();
     app.add_option("-o,--output", output_filename, "Output filename")->required();
-    app.add_option("-l,--lambda", lambda, "Lambda parameter for variable blocks");
     auto var_block_opt = app.add_flag("--variable-block", variable_block, "Variable length blocks");
+    auto var_block_param_opt = app.add_option("-b,--block", fixed_block_size, "Block size for fixed-length blocks")->excludes(var_block_opt);
+    app.add_option("-l,--lambda", lambda, "Lambda parameter for variable blocks")->excludes(var_block_param_opt);
     app.add_flag("--compress", compress, "Compress additional data");
     app.add_flag("--range", range, "Create docid-range based data")->excludes(var_block_opt);
 
-    
     CLI11_PARSE(app, argc, argv);
 
     partition_type p_type =
@@ -42,20 +45,30 @@ int main(int argc, const char **argv) {
         (p_type == partition_type::fixed_blocks) ? "static partition" : "variable partition";
     spdlog::info("Block based wand creation with {}", partition_type_name);
 
-    binary_collection      sizes_coll((input_basename + ".sizes").c_str());
+    binary_collection sizes_coll((input_basename + ".sizes").c_str());
     binary_freq_collection coll(input_basename.c_str());
+
+    boost::variant<float, uint64_t> block_size = uint64_t(0);
+    if (lambda != 0.0f && variable_block) {
+        block_size = lambda;
+    } else if (lambda != 0.0f && !variable_block) {
+        spdlog::error("Lambda set without --variable-block. Ignoring.");
+        return EXIT_FAILURE;
+    } else if (fixed_block_size != 0 && !variable_block) {
+        block_size = fixed_block_size;
+    }
 
     if (compress) {
         wand_data<bm25, wand_data_compressed<bm25, uniform_score_compressor>> wdata(
-            sizes_coll.begin()->begin(), coll.num_docs(), coll, p_type, lambda);
+            sizes_coll.begin()->begin(), coll.num_docs(), coll, p_type, block_size);
         mapper::freeze(wdata, output_filename.c_str());
-    } else if(range) {
+    } else if (range) {
         wand_data<bm25, wand_data_range<128, 1024, bm25>> wdata(
             sizes_coll.begin()->begin(), coll.num_docs(), coll, p_type);
         mapper::freeze(wdata, output_filename.c_str());
     } else {
         wand_data<bm25, wand_data_raw<bm25>> wdata(
-            sizes_coll.begin()->begin(), coll.num_docs(), coll, p_type, lambda);
+            sizes_coll.begin()->begin(), coll.num_docs(), coll, p_type, block_size);
         mapper::freeze(wdata, output_filename.c_str());
     }
 }

--- a/test/test_bmw_queries.cpp
+++ b/test/test_bmw_queries.cpp
@@ -25,8 +25,7 @@ struct IndexData {
           wdata(document_sizes.begin()->begin(),
                 collection.num_docs(),
                 collection,
-                partition_type::variable_blocks,
-                boost::variant<float, uint64_t>(float(0.0f)))
+                BlockSize(VariableBlock()))
  
     {
         typename Index::builder builder(collection.num_docs(), params);
@@ -97,8 +96,7 @@ TEST_CASE("block_max_wand", "[bmw][query][ranked][integration]", )
         WandTypePlain wdata_fixed(data->document_sizes.begin()->begin(),
                                   data->collection.num_docs(),
                                   data->collection,
-                                  partition_type::fixed_blocks,
-                                  boost::variant<float, uint64_t>(uint64_t(0)));
+                                  BlockSize(FixedBlock()));
         test(wdata_fixed);
     }
     SECTION("Uniform")
@@ -106,8 +104,7 @@ TEST_CASE("block_max_wand", "[bmw][query][ranked][integration]", )
         WandTypeUniform wdata_uniform(data->document_sizes.begin()->begin(),
                                       data->collection.num_docs(),
                                       data->collection,
-                                      partition_type::variable_blocks,
-                                      boost::variant<float, uint64_t>(float(0.0f)));
+                                      BlockSize(VariableBlock()));
         test(wdata_uniform);
     }
 }

--- a/test/test_bmw_queries.cpp
+++ b/test/test_bmw_queries.cpp
@@ -3,11 +3,11 @@
 
 #include "test_common.hpp"
 
-#include "pisa_config.hpp"
-#include "index_types.hpp"
-#include "query/queries.hpp"
-#include "cursor/max_scored_cursor.hpp"
 #include "cursor/block_max_scored_cursor.hpp"
+#include "cursor/max_scored_cursor.hpp"
+#include "index_types.hpp"
+#include "pisa_config.hpp"
+#include "query/queries.hpp"
 
 using namespace pisa;
 
@@ -26,7 +26,7 @@ struct IndexData {
                 collection.num_docs(),
                 collection,
                 BlockSize(VariableBlock()))
- 
+
     {
         typename Index::builder builder(collection.num_docs(), params);
         for (auto const &plist : collection) {

--- a/test/test_bmw_queries.cpp
+++ b/test/test_bmw_queries.cpp
@@ -25,7 +25,9 @@ struct IndexData {
           wdata(document_sizes.begin()->begin(),
                 collection.num_docs(),
                 collection,
-                partition_type::variable_blocks)
+                partition_type::variable_blocks,
+                boost::variant<float, uint64_t>(float(0.0f)))
+ 
     {
         typename Index::builder builder(collection.num_docs(), params);
         for (auto const &plist : collection) {
@@ -95,7 +97,8 @@ TEST_CASE("block_max_wand", "[bmw][query][ranked][integration]", )
         WandTypePlain wdata_fixed(data->document_sizes.begin()->begin(),
                                   data->collection.num_docs(),
                                   data->collection,
-                                  partition_type::fixed_blocks);
+                                  partition_type::fixed_blocks,
+                                  boost::variant<float, uint64_t>(uint64_t(0)));
         test(wdata_fixed);
     }
     SECTION("Uniform")
@@ -103,7 +106,8 @@ TEST_CASE("block_max_wand", "[bmw][query][ranked][integration]", )
         WandTypeUniform wdata_uniform(data->document_sizes.begin()->begin(),
                                       data->collection.num_docs(),
                                       data->collection,
-                                      partition_type::variable_blocks);
+                                      partition_type::variable_blocks,
+                                      boost::variant<float, uint64_t>(float(0.0f)));
         test(wdata_uniform);
     }
 }

--- a/test/test_ranked_queries.cpp
+++ b/test/test_ranked_queries.cpp
@@ -23,7 +23,11 @@ struct IndexData {
     IndexData()
         : collection(PISA_SOURCE_DIR "/test/test_data/test_collection"),
           document_sizes(PISA_SOURCE_DIR "/test/test_data/test_collection.sizes"),
-          wdata(document_sizes.begin()->begin(), collection.num_docs(), collection)
+          wdata(document_sizes.begin()->begin(),
+                collection.num_docs(),
+                collection,
+                BlockSize(FixedBlock()))
+
     {
         typename Index::builder builder(collection.num_docs(), params);
         for (auto const &plist : collection) {
@@ -76,19 +80,21 @@ class ranked_or_taat_query_acc : public ranked_or_taat_query {
     using ranked_or_taat_query::ranked_or_taat_query;
 
     template <typename CursorRange>
-    uint64_t operator()(CursorRange &&cursors, uint64_t max_docid) {
-        Acc                          accumulator(max_docid);
+    uint64_t operator()(CursorRange &&cursors, uint64_t max_docid)
+    {
+        Acc accumulator(max_docid);
         return ranked_or_taat_query::operator()(cursors, max_docid, accumulator);
     }
 };
 
-template<typename T>
+template <typename T>
 class range_query_128 : public range_query<T> {
    public:
     using range_query<T>::range_query;
 
     template <typename CursorRange>
-    uint64_t operator()(CursorRange &&cursors, uint64_t max_docid) {
+    uint64_t operator()(CursorRange &&cursors, uint64_t max_docid)
+    {
         return range_query<T>::operator()(cursors, max_docid, 128);
     }
 };


### PR DESCRIPTION
Some potential issues:
- I am not particularly familiar with the `boost::variant` stuff, so please check that I am not abusing it.
- I was able to handle most of the command line argument interactions using the CLI `excludes`, but this does not work for supplying `--lambda` without `--variable-block` so I wrote an explicit case to catch that one.

Also updated the documentation. Please suggest changes and I will try to fix ASAP.