### PR TITLE
Rename PEF

### DIFF
--- a/include/pisa/index_types.hpp
+++ b/include/pisa/index_types.hpp
@@ -27,10 +27,10 @@ using ef_index = freq_index<compact_elias_fano, positive_sequence<strict_elias_f
 
 using single_index = freq_index<indexed_sequence, positive_sequence<>>;
 
-using uniform_index = freq_index<uniform_partitioned_sequence<>,
+using pefuniform_index = freq_index<uniform_partitioned_sequence<>,
                                  positive_sequence<uniform_partitioned_sequence<strict_sequence>>>;
 
-using opt_index =
+using pefopt_index =
     freq_index<partitioned_sequence<>, positive_sequence<partitioned_sequence<strict_sequence>>>;
 
 using block_optpfor_index       = block_freq_index<pisa::optpfor_block>;
@@ -48,7 +48,7 @@ using block_mixed_index         = block_freq_index<pisa::mixed_block>;
 } // namespace pisa
 
 #define PISA_INDEX_TYPES                                                                    \
-    (ef)(single)(uniform)(opt)(block_optpfor)(block_varintg8iu)(block_streamvbyte)(         \
+    (ef)(single)(pefuniform)(pefopt)(block_optpfor)(block_varintg8iu)(block_streamvbyte)(         \
         block_maskedvbyte)(block_interpolative)(block_qmx)(block_varintgb)(block_simple8b)( \
         block_simple16)(block_simdbp)(block_mixed)
 #define PISA_BLOCK_INDEX_TYPES                                                                    \

--- a/src/create_freq_index.cpp
+++ b/src/create_freq_index.cpp
@@ -22,7 +22,7 @@
 template <typename Collection>
 void dump_index_specific_stats(Collection const &, std::string const &) {}
 
-void dump_index_specific_stats(pisa::uniform_index const &coll, std::string const &type) {
+void dump_index_specific_stats(pisa::uniformpef_index const &coll, std::string const &type) {
     pisa::stats_line()("type", type)("log_partition_size", int(coll.params().log_partition_size));
 }
 

--- a/src/create_freq_index.cpp
+++ b/src/create_freq_index.cpp
@@ -26,7 +26,7 @@ void dump_index_specific_stats(pisa::uniform_index const &coll, std::string cons
     pisa::stats_line()("type", type)("log_partition_size", int(coll.params().log_partition_size));
 }
 
-void dump_index_specific_stats(pisa::opt_index const &coll, std::string const &type) {
+void dump_index_specific_stats(pisa::optpef_index const &coll, std::string const &type) {
     auto const &conf = pisa::configuration::get();
 
     uint64_t length_threshold = 4096;

--- a/src/create_freq_index.cpp
+++ b/src/create_freq_index.cpp
@@ -22,11 +22,11 @@
 template <typename Collection>
 void dump_index_specific_stats(Collection const &, std::string const &) {}
 
-void dump_index_specific_stats(pisa::uniformpef_index const &coll, std::string const &type) {
+void dump_index_specific_stats(pisa::pefuniform_index const &coll, std::string const &type) {
     pisa::stats_line()("type", type)("log_partition_size", int(coll.params().log_partition_size));
 }
 
-void dump_index_specific_stats(pisa::optpef_index const &coll, std::string const &type) {
+void dump_index_specific_stats(pisa::pefopt_index const &coll, std::string const &type) {
     auto const &conf = pisa::configuration::get();
 
     uint64_t length_threshold = 4096;

--- a/test/test_wand_data.cpp
+++ b/test/test_wand_data.cpp
@@ -49,7 +49,7 @@ TEST_CASE("wand_data_range")
             term_id += 1;
         }
     }
-    using index_type = opt_index;
+    using index_type = pefopt_index;
     index_type index;
     global_parameters params;
     index_type::builder builder(collection.num_docs(), params);


### PR DESCRIPTION
Changes proposed in this pull request:
- Rename `opt` to `pefopt`
- Rename `uniform` to `pefuniform`
