### PR TITLE
Compute norm_lens at run time

### DIFF
--- a/include/pisa/scorer/score_function.hpp
+++ b/include/pisa/scorer/score_function.hpp
@@ -7,6 +7,6 @@ struct Score_Function {
     const Wand& wdata;
 
     [[nodiscard]] float operator()(uint32_t doc, uint32_t freq) const {
-        return query_weight * Scorer::doc_term_weight(freq, wdata.norm_len(doc));
+        return query_weight * Scorer::doc_term_weight(freq, wdata.doc_len(doc)/wdata.avg_len());
     }
 };

--- a/include/pisa/scorer/score_function.hpp
+++ b/include/pisa/scorer/score_function.hpp
@@ -3,10 +3,11 @@
 
 template <typename Scorer, typename Wand>
 struct Score_Function {
-    float       query_weight;
-    const Wand& wdata;
+    float query_weight;
+    const Wand &wdata;
 
-    [[nodiscard]] float operator()(uint32_t doc, uint32_t freq) const {
-        return query_weight * Scorer::doc_term_weight(freq, wdata.doc_len(doc)/wdata.avg_len());
+    [[nodiscard]] float operator()(uint32_t doc, uint32_t freq) const
+    {
+        return query_weight * Scorer::doc_term_weight(freq, wdata.doc_len(doc) / wdata.avg_len());
     }
 };

--- a/include/pisa/scorer/score_function.hpp
+++ b/include/pisa/scorer/score_function.hpp
@@ -8,6 +8,6 @@ struct Score_Function {
 
     [[nodiscard]] float operator()(uint32_t doc, uint32_t freq) const
     {
-        return query_weight * Scorer::doc_term_weight(freq, wdata.doc_len(doc) / wdata.avg_len());
+        return query_weight * Scorer::doc_term_weight(freq, wdata.norm_len(doc));
     }
 };

--- a/include/pisa/wand_data.hpp
+++ b/include/pisa/wand_data.hpp
@@ -57,7 +57,7 @@ class wand_data {
 
     inline float norm_len(uint64_t doc_id) const
     {
-        return static_cast<float>(m_doc_lens[doc_id]) / m_avg_len;
+        return m_doc_lens[doc_id] / m_avg_len;
     }
 
     size_t doc_len(uint64_t doc_id) const { return m_doc_lens[doc_id]; }

--- a/include/pisa/wand_data.hpp
+++ b/include/pisa/wand_data.hpp
@@ -21,16 +21,19 @@ class wand_data {
     wand_data() {}
 
     template <typename LengthsIterator>
-    wand_data(LengthsIterator len_it, uint64_t num_docs, binary_freq_collection const &coll,
-              BlockSize block_size) {
+    wand_data(LengthsIterator len_it,
+              uint64_t num_docs,
+              binary_freq_collection const &coll,
+              BlockSize block_size)
+    {
         std::vector<float> doc_lens(num_docs);
         std::vector<float> max_term_weight;
-        global_parameters  params;
-        double             lens_sum = 0;
+        global_parameters params;
+        double lens_sum = 0;
         spdlog::info("Reading sizes...");
 
         for (size_t i = 0; i < num_docs; ++i) {
-            float len   = *len_it++;
+            float len = *len_it++;
             doc_lens[i] = len;
             lens_sum += len;
         }
@@ -63,15 +66,16 @@ class wand_data {
     const block_wand_type &get_block_wand() const { return m_block_wand; }
 
     template <typename Visitor>
-    void map(Visitor &visit) {
+    void map(Visitor &visit)
+    {
         visit(m_block_wand, "m_block_wand")(m_doc_lens, "m_doc_lens")(m_avg_len, "m_avg_len")(
             m_max_term_weight, "m_max_term_weight");
     }
 
    private:
-    block_wand_type                m_block_wand;
+    block_wand_type m_block_wand;
     mapper::mappable_vector<float> m_doc_lens;
-    float                          m_avg_len;
+    float m_avg_len;
     mapper::mappable_vector<float> m_max_term_weight;
 };
-}  // namespace pisa
+} // namespace pisa

--- a/include/pisa/wand_data.hpp
+++ b/include/pisa/wand_data.hpp
@@ -21,43 +21,40 @@ class wand_data {
     wand_data() {}
 
     template <typename LengthsIterator>
-    wand_data(LengthsIterator len_it,
-              uint64_t num_docs,
-              binary_freq_collection const &coll,
-              BlockSize block_size)
-    {
-        std::vector<float> norm_lens(num_docs);
+    wand_data(LengthsIterator len_it, uint64_t num_docs, binary_freq_collection const &coll,
+              BlockSize block_size) {
+        std::vector<float> doc_lens(num_docs);
         std::vector<float> max_term_weight;
-        global_parameters params;
-        double lens_sum = 0;
+        global_parameters  params;
+        double             lens_sum = 0;
         spdlog::info("Reading sizes...");
 
         for (size_t i = 0; i < num_docs; ++i) {
-            float len = *len_it++;
-            norm_lens[i] = len;
+            float len   = *len_it++;
+            doc_lens[i] = len;
             lens_sum += len;
         }
 
         float avg_len = float(lens_sum / double(num_docs));
-        for (auto &norm_len : norm_lens) {
-            norm_len /= avg_len;
-        }
 
         typename block_wand_type::builder builder(coll, params);
         {
             pisa::progress progress("Processing posting lists", coll.size());
             for (auto const &seq : coll) {
-                auto v = builder.add_sequence(seq, coll, norm_lens, block_size);
+                auto v = builder.add_sequence(seq, coll, doc_lens, avg_len, block_size);
                 max_term_weight.push_back(v);
                 progress.update(1);
             }
         }
         builder.build(m_block_wand);
-        m_norm_lens.steal(norm_lens);
+        m_doc_lens.steal(doc_lens);
         m_max_term_weight.steal(max_term_weight);
+        m_avg_len = avg_len;
     }
 
-    float norm_len(uint64_t doc_id) const { return m_norm_lens[doc_id]; }
+    float doc_len(uint64_t doc_id) const { return m_doc_lens[doc_id]; }
+
+    float avg_len() const { return m_avg_len; }
 
     float max_term_weight(uint64_t list) const { return m_max_term_weight[list]; }
 
@@ -66,15 +63,15 @@ class wand_data {
     const block_wand_type &get_block_wand() const { return m_block_wand; }
 
     template <typename Visitor>
-    void map(Visitor &visit)
-    {
-        visit(m_block_wand, "m_block_wand")(m_norm_lens, "m_norm_lens")(m_max_term_weight,
-                                                                        "m_max_term_weight");
+    void map(Visitor &visit) {
+        visit(m_block_wand, "m_block_wand")(m_doc_lens, "m_doc_lens")(m_avg_len, "m_avg_len")(
+            m_max_term_weight, "m_max_term_weight");
     }
 
    private:
-    block_wand_type m_block_wand;
-    mapper::mappable_vector<float> m_norm_lens;
+    block_wand_type                m_block_wand;
+    mapper::mappable_vector<float> m_doc_lens;
+    float                          m_avg_len;
     mapper::mappable_vector<float> m_max_term_weight;
 };
-} // namespace pisa
+}  // namespace pisa

--- a/include/pisa/wand_data.hpp
+++ b/include/pisa/wand_data.hpp
@@ -26,7 +26,7 @@ class wand_data {
               binary_freq_collection const &coll,
               BlockSize block_size)
     {
-        std::vector<float> doc_lens(num_docs);
+        std::vector<uint32_t> doc_lens(num_docs);
         std::vector<float> max_term_weight;
         global_parameters params;
         double lens_sum = 0;
@@ -55,7 +55,12 @@ class wand_data {
         m_avg_len = avg_len;
     }
 
-    float doc_len(uint64_t doc_id) const { return m_doc_lens[doc_id]; }
+    inline float norm_len(uint64_t doc_id) const
+    {
+        return static_cast<float>(m_doc_lens[doc_id]) / m_avg_len;
+    }
+
+    size_t doc_len(uint64_t doc_id) const { return m_doc_lens[doc_id]; }
 
     float avg_len() const { return m_avg_len; }
 
@@ -74,7 +79,7 @@ class wand_data {
 
    private:
     block_wand_type m_block_wand;
-    mapper::mappable_vector<float> m_doc_lens;
+    mapper::mappable_vector<uint32_t> m_doc_lens;
     float m_avg_len;
     mapper::mappable_vector<float> m_max_term_weight;
 };

--- a/include/pisa/wand_data_compressed.hpp
+++ b/include/pisa/wand_data_compressed.hpp
@@ -17,7 +17,7 @@
 
 namespace pisa {
 namespace {
-static const size_t score_bits_size = broadword::msb(configuration::get().reference_size);
+    static const size_t score_bits_size = broadword::msb(configuration::get().reference_size);
 }
 
 class uniform_score_compressor {
@@ -27,9 +27,12 @@ class uniform_score_compressor {
         builder(uint64_t num_docs, global_parameters const &params)
             : m_params(params),
               m_num_docs((num_docs + 1) << score_bits_size),
-              m_docs_sequences(params) {}
+              m_docs_sequences(params)
+        {
+        }
 
-        std::vector<uint32_t> compress_data(std::vector<float> effective_scores) {
+        std::vector<uint32_t> compress_data(std::vector<float> effective_scores)
+        {
             float quant = 1.f / configuration::get().reference_size;
 
             // Partition scores.
@@ -37,23 +40,26 @@ class uniform_score_compressor {
             score_indexes.reserve(effective_scores.size());
             for (const auto &score : effective_scores) {
                 size_t pos = 1;
-                while (score > quant * pos) pos++;
+                while (score > quant * pos)
+                    pos++;
                 score_indexes.push_back(pos - 1);
             }
             return score_indexes;
         }
 
         template <typename Sequence = compact_elias_fano, typename DocsIterator>
-        void add_posting_list(uint64_t n, DocsIterator docs_begin, DocsIterator score_begin) {
+        void add_posting_list(uint64_t n, DocsIterator docs_begin, DocsIterator score_begin)
+        {
             std::vector<uint64_t> temp;
             for (size_t i = 0; i < n; ++i) {
                 uint64_t elem = *(docs_begin + i);
-                elem          = elem << score_bits_size;
+                elem = elem << score_bits_size;
                 elem += *(score_begin + i);
                 temp.push_back(elem);
             }
 
-            if (!n) throw std::invalid_argument("List must be nonempty");
+            if (!n)
+                throw std::invalid_argument("List must be nonempty");
             bit_vector_builder docs_bits;
             write_gamma_nonzero(docs_bits, n);
             Sequence::write(docs_bits, temp.begin(), m_num_docs, n, m_params);
@@ -67,12 +73,13 @@ class uniform_score_compressor {
         uint64_t num_docs() { return m_num_docs; }
 
        private:
-        global_parameters             m_params;
-        uint64_t                      m_num_docs;
+        global_parameters m_params;
+        uint64_t m_num_docs;
         bitvector_collection::builder m_docs_sequences;
     };
 
-    static float inline score(uint32_t index) {
+    static float inline score(uint32_t index)
+    {
         const float quant = 1.f / configuration::get().reference_size;
         return quant * (index + 1);
     }
@@ -87,19 +94,26 @@ class wand_data_compressed {
             : total_elements(0),
               total_blocks(0),
               params(params),
-              compressor_builder(coll.num_docs(), params) {
+              compressor_builder(coll.num_docs(), params)
+        {
             spdlog::info("Storing max weight for each list and for each block...");
         }
 
         float add_sequence(binary_freq_collection::sequence const &seq,
-                           binary_freq_collection const &coll, std::vector<float> const &doc_lens,
-                           float avg_len, BlockSize block_size) {
+                           binary_freq_collection const &coll,
+                           std::vector<float> const &doc_lens,
+                           float avg_len,
+                           BlockSize block_size)
+        {
             if (seq.docs.size() > configuration::get().threshold_wand_list) {
                 auto t =
                     block_size.type() == typeid(FixedBlock)
-                        ? static_block_partition(seq, doc_lens, avg_len,
-                                                 boost::get<FixedBlock>(block_size).size)
-                        : variable_block_partition(coll, seq, doc_lens, avg_len,
+                        ? static_block_partition(
+                              seq, doc_lens, avg_len, boost::get<FixedBlock>(block_size).size)
+                        : variable_block_partition(coll,
+                                                   seq,
+                                                   doc_lens,
+                                                   avg_len,
                                                    boost::get<VariableBlock>(block_size).lambda);
 
                 auto ind = compressor_builder.compress_data(t.second);
@@ -118,19 +132,20 @@ class wand_data_compressed {
             return max_term_weight.back();
         }
 
-        void build(wand_data_compressed &wdata) {
+        void build(wand_data_compressed &wdata)
+        {
             wdata.m_num_docs = compressor_builder.num_docs();
-            wdata.m_params   = compressor_builder.params();
+            wdata.m_params = compressor_builder.params();
             compressor_builder.build(wdata.m_docs_sequences);
             spdlog::info("number of elements / number of blocks: {}",
                          (float)total_elements / (float)total_blocks);
         }
 
-        uint64_t                           total_elements;
-        uint64_t                           total_blocks;
-        std::vector<float>                 score_references;
-        std::vector<float>                 max_term_weight;
-        global_parameters const &          params;
+        uint64_t total_elements;
+        uint64_t total_blocks;
+        std::vector<float> score_references;
+        std::vector<float> max_term_weight;
+        global_parameters const &params;
         typename score_compressor::builder compressor_builder;
     };
 
@@ -140,19 +155,21 @@ class wand_data_compressed {
        public:
         enumerator(compact_elias_fano::enumerator docs_enum) : m_docs_enum(docs_enum) { reset(); }
 
-        void reset() {
-            uint64_t val      = m_docs_enum.move(0).second;
-            m_cur_docid       = val >> score_bits_size;
-            uint64_t mask     = configuration::get().reference_size - 1;
+        void reset()
+        {
+            uint64_t val = m_docs_enum.move(0).second;
+            m_cur_docid = val >> score_bits_size;
+            uint64_t mask = configuration::get().reference_size - 1;
             m_cur_score_index = (val & mask);
         }
 
-        void PISA_FLATTEN_FUNC next_geq(uint64_t lower_bound) {
+        void PISA_FLATTEN_FUNC next_geq(uint64_t lower_bound)
+        {
             if (docid() != lower_bound) {
-                lower_bound       = lower_bound << score_bits_size;
-                auto val          = m_docs_enum.next_geq(lower_bound);
-                m_cur_docid       = val.second >> score_bits_size;
-                uint64_t mask     = configuration::get().reference_size - 1;
+                lower_bound = lower_bound << score_bits_size;
+                auto val = m_docs_enum.next_geq(lower_bound);
+                m_cur_docid = val.second >> score_bits_size;
+                uint64_t mask = configuration::get().reference_size - 1;
                 m_cur_score_index = (val.second & mask);
             }
         }
@@ -162,8 +179,8 @@ class wand_data_compressed {
         uint64_t PISA_FLATTEN_FUNC docid() const { return m_cur_docid; }
 
        private:
-        uint64_t                       m_cur_docid;
-        uint64_t                       m_cur_score_index;
+        uint64_t m_cur_docid;
+        uint64_t m_cur_score_index;
         compact_elias_fano::enumerator m_docs_enum;
     };
 
@@ -171,11 +188,12 @@ class wand_data_compressed {
 
     uint64_t num_docs() const { return m_num_docs; }
 
-    enumerator get_enum(size_t i) const {
+    enumerator get_enum(size_t i) const
+    {
         assert(i < size());
         auto docs_it = m_docs_sequences.get(m_params, i);
 
-        uint64_t                                n = read_gamma_nonzero(docs_it);
+        uint64_t n = read_gamma_nonzero(docs_it);
         typename compact_elias_fano::enumerator docs_enum(
             m_docs_sequences.bits(), docs_it.position(), num_docs(), n, m_params);
 
@@ -183,14 +201,15 @@ class wand_data_compressed {
     }
 
     template <typename Visitor>
-    void map(Visitor &visit) {
+    void map(Visitor &visit)
+    {
         visit(m_params, "m_params")(m_num_docs, "m_num_docs")(m_docs_sequences, "m_docs_sequences");
     }
 
    private:
-    global_parameters    m_params;
-    uint64_t             m_num_docs;
+    global_parameters m_params;
+    uint64_t m_num_docs;
     bitvector_collection m_docs_sequences;
 };
 
-}  // namespace pisa
+} // namespace pisa

--- a/include/pisa/wand_data_compressed.hpp
+++ b/include/pisa/wand_data_compressed.hpp
@@ -101,7 +101,7 @@ class wand_data_compressed {
 
         float add_sequence(binary_freq_collection::sequence const &seq,
                            binary_freq_collection const &coll,
-                           std::vector<float> const &doc_lens,
+                           std::vector<uint32_t> const &doc_lens,
                            float avg_len,
                            BlockSize block_size)
         {

--- a/include/pisa/wand_data_range.hpp
+++ b/include/pisa/wand_data_range.hpp
@@ -57,7 +57,7 @@ class wand_data_range {
 
         float add_sequence(binary_freq_collection::sequence const &term_seq,
                            binary_freq_collection const &coll,
-                           std::vector<float> const &doc_lens,
+                           std::vector<uint32_t> const &doc_lens,
                            float avg_len,
                            [[maybe_unused]] BlockSize block_size)
         {

--- a/include/pisa/wand_data_range.hpp
+++ b/include/pisa/wand_data_range.hpp
@@ -16,7 +16,8 @@ template <size_t range_size = 128, size_t min_list_lenght = 1024, typename Score
 class wand_data_range {
    public:
     template <typename List, typename Fn>
-    void for_each_posting(List &list, Fn func) const {
+    void for_each_posting(List &list, Fn func) const
+    {
         while (list.position() < list.size()) {
             func(list.docid(), list.freq());
             list.next();
@@ -24,49 +25,57 @@ class wand_data_range {
     }
 
     template <typename List, typename Fn>
-    auto compute_block_max_scores(List &list, Fn scorer) const {
+    auto compute_block_max_scores(List &list, Fn scorer) const
+    {
         std::vector<float> block_max_scores(m_blocks_num, 0.0f);
         for_each_posting(list, [&](auto docid, auto freq) {
             float &current_max = block_max_scores[docid / range_size];
-            current_max        = std::max(current_max, scorer(docid, freq));
+            current_max = std::max(current_max, scorer(docid, freq));
         });
         return block_max_scores;
     };
 
     class builder {
        public:
-        builder(binary_freq_collection const &            coll,
+        builder(binary_freq_collection const &coll,
                 [[maybe_unused]] global_parameters const &params)
             : blocks_num(ceil_div(coll.num_docs(), range_size)),
               total_elements(0),
               blocks_start{0},
-              block_max_term_weight{} {
+              block_max_term_weight{}
+        {
             auto posting_lists = std::distance(coll.begin(), coll.end());
             spdlog::info("Storing max weight for each list and for each block...");
             spdlog::info(
                 "Range size: {}. Number of docs: {}."
                 "Blocks per posting list: {}. Posting lists: {}.",
-                range_size, coll.num_docs(), blocks_num, posting_lists);
+                range_size,
+                coll.num_docs(),
+                blocks_num,
+                posting_lists);
         }
 
         float add_sequence(binary_freq_collection::sequence const &term_seq,
-                           binary_freq_collection const &coll, std::vector<float> const &doc_lens,
-                           float avg_len, [[maybe_unused]] BlockSize block_size) {
+                           binary_freq_collection const &coll,
+                           std::vector<float> const &doc_lens,
+                           float avg_len,
+                           [[maybe_unused]] BlockSize block_size)
+        {
             float max_score = 0.0f;
 
             std::vector<float> b_max(blocks_num, 0.0f);
             for (auto i = 0; i < term_seq.docs.size(); ++i) {
                 uint64_t docid = *(term_seq.docs.begin() + i);
-                uint64_t freq  = *(term_seq.freqs.begin() + i);
-                float    score = Scorer::doc_term_weight(freq, doc_lens[docid] / avg_len);
-                max_score      = std::max(max_score, score);
-                size_t pos     = docid / range_size;
-                float &bm      = b_max[pos];
-                bm             = std::max(bm, score);
+                uint64_t freq = *(term_seq.freqs.begin() + i);
+                float score = Scorer::doc_term_weight(freq, doc_lens[docid] / avg_len);
+                max_score = std::max(max_score, score);
+                size_t pos = docid / range_size;
+                float &bm = b_max[pos];
+                bm = std::max(bm, score);
             }
             if (term_seq.docs.size() >= min_list_lenght) {
-                block_max_term_weight.insert(block_max_term_weight.end(), b_max.begin(),
-                                             b_max.end());
+                block_max_term_weight.insert(
+                    block_max_term_weight.end(), b_max.begin(), b_max.end());
                 blocks_start.push_back(b_max.size() + blocks_start.back());
                 total_elements += term_seq.docs.size();
             } else {
@@ -75,7 +84,8 @@ class wand_data_range {
             return max_score;
         }
 
-        void build(wand_data_range &wdata) {
+        void build(wand_data_range &wdata)
+        {
             wdata.m_blocks_num = blocks_num;
             wdata.m_blocks_start.steal(blocks_start);
             wdata.m_block_max_term_weight.steal(block_max_term_weight);
@@ -83,42 +93,46 @@ class wand_data_range {
                          static_cast<float>(total_elements) / wdata.m_block_max_term_weight.size());
         }
 
-        uint64_t              blocks_num;
-        uint64_t              total_elements;
+        uint64_t blocks_num;
+        uint64_t total_elements;
         std::vector<uint64_t> blocks_start;
-        std::vector<float>    block_max_term_weight;
+        std::vector<float> block_max_term_weight;
     };
 
     class enumerator {
         friend class wand_data_range;
 
        public:
-        enumerator(uint32_t                              _block_start,
+        enumerator(uint32_t _block_start,
                    mapper::mappable_vector<float> const &block_max_term_weight)
-            : cur_pos(0),
-              block_start(_block_start),
-              m_block_max_term_weight(block_max_term_weight) {}
+            : cur_pos(0), block_start(_block_start), m_block_max_term_weight(block_max_term_weight)
+        {
+        }
 
         void PISA_NOINLINE next_block() { cur_pos += 1; }
         void PISA_NOINLINE next_geq(uint64_t lower_bound) { cur_pos = lower_bound / range_size; }
         uint64_t PISA_FLATTEN_FUNC docid() const { return (cur_pos + 1) * range_size; }
 
-        float PISA_FLATTEN_FUNC score() const {
+        float PISA_FLATTEN_FUNC score() const
+        {
             return m_block_max_term_weight[block_start + cur_pos];
         }
 
        private:
-        uint64_t                              cur_pos;
-        uint64_t                              block_start;
+        uint64_t cur_pos;
+        uint64_t block_start;
         mapper::mappable_vector<float> const &m_block_max_term_weight;
     };
 
-    enumerator get_enum(uint32_t i) const {
+    enumerator get_enum(uint32_t i) const
+    {
         return enumerator(m_blocks_start[i], m_block_max_term_weight);
     }
 
-    static std::vector<bool> compute_live_blocks(std::vector<enumerator> &enums, float threshold,
-                                                 std::pair<uint32_t, uint32_t> document_range) {
+    static std::vector<bool> compute_live_blocks(std::vector<enumerator> &enums,
+                                                 float threshold,
+                                                 std::pair<uint32_t, uint32_t> document_range)
+    {
         size_t len = ceil_div((document_range.second - document_range.first), range_size);
         std::vector<bool> live_blocks(len);
         for (auto &&e : enums) {
@@ -136,15 +150,16 @@ class wand_data_range {
     }
 
     template <typename Visitor>
-    void map(Visitor &visit) {
+    void map(Visitor &visit)
+    {
         visit(m_blocks_num, "m_blocks_num")(m_blocks_start, "m_blocks_start")(
             m_block_max_term_weight, "m_block_max_term_weight");
     }
 
    private:
-    uint64_t                          m_blocks_num;
+    uint64_t m_blocks_num;
     mapper::mappable_vector<uint64_t> m_blocks_start;
-    mapper::mappable_vector<float>    m_block_max_term_weight;
+    mapper::mappable_vector<float> m_block_max_term_weight;
 };
 
-}  // namespace pisa
+} // namespace pisa

--- a/include/pisa/wand_data_range.hpp
+++ b/include/pisa/wand_data_range.hpp
@@ -16,8 +16,7 @@ template <size_t range_size = 128, size_t min_list_lenght = 1024, typename Score
 class wand_data_range {
    public:
     template <typename List, typename Fn>
-    void for_each_posting(List &list, Fn func) const
-    {
+    void for_each_posting(List &list, Fn func) const {
         while (list.position() < list.size()) {
             func(list.docid(), list.freq());
             list.next();
@@ -25,56 +24,49 @@ class wand_data_range {
     }
 
     template <typename List, typename Fn>
-    auto compute_block_max_scores(List &list, Fn scorer) const
-    {
+    auto compute_block_max_scores(List &list, Fn scorer) const {
         std::vector<float> block_max_scores(m_blocks_num, 0.0f);
         for_each_posting(list, [&](auto docid, auto freq) {
             float &current_max = block_max_scores[docid / range_size];
-            current_max = std::max(current_max, scorer(docid, freq));
+            current_max        = std::max(current_max, scorer(docid, freq));
         });
         return block_max_scores;
     };
 
     class builder {
        public:
-        builder(binary_freq_collection const &coll,
+        builder(binary_freq_collection const &            coll,
                 [[maybe_unused]] global_parameters const &params)
             : blocks_num(ceil_div(coll.num_docs(), range_size)),
               total_elements(0),
               blocks_start{0},
-              block_max_term_weight{}
-        {
+              block_max_term_weight{} {
             auto posting_lists = std::distance(coll.begin(), coll.end());
             spdlog::info("Storing max weight for each list and for each block...");
             spdlog::info(
                 "Range size: {}. Number of docs: {}."
                 "Blocks per posting list: {}. Posting lists: {}.",
-                range_size,
-                coll.num_docs(),
-                blocks_num,
-                posting_lists);
+                range_size, coll.num_docs(), blocks_num, posting_lists);
         }
 
         float add_sequence(binary_freq_collection::sequence const &term_seq,
-                           binary_freq_collection const &coll,
-                           std::vector<float> const &norm_lens,
-                           [[maybe_unused]] BlockSize block_size)
-        {
+                           binary_freq_collection const &coll, std::vector<float> const &doc_lens,
+                           float avg_len, [[maybe_unused]] BlockSize block_size) {
             float max_score = 0.0f;
 
             std::vector<float> b_max(blocks_num, 0.0f);
             for (auto i = 0; i < term_seq.docs.size(); ++i) {
                 uint64_t docid = *(term_seq.docs.begin() + i);
-                uint64_t freq = *(term_seq.freqs.begin() + i);
-                float score = Scorer::doc_term_weight(freq, norm_lens[docid]);
-                max_score = std::max(max_score, score);
-                size_t pos = docid / range_size;
-                float &bm = b_max[pos];
-                bm = std::max(bm, score);
+                uint64_t freq  = *(term_seq.freqs.begin() + i);
+                float    score = Scorer::doc_term_weight(freq, doc_lens[docid] / avg_len);
+                max_score      = std::max(max_score, score);
+                size_t pos     = docid / range_size;
+                float &bm      = b_max[pos];
+                bm             = std::max(bm, score);
             }
             if (term_seq.docs.size() >= min_list_lenght) {
-                block_max_term_weight.insert(
-                    block_max_term_weight.end(), b_max.begin(), b_max.end());
+                block_max_term_weight.insert(block_max_term_weight.end(), b_max.begin(),
+                                             b_max.end());
                 blocks_start.push_back(b_max.size() + blocks_start.back());
                 total_elements += term_seq.docs.size();
             } else {
@@ -83,8 +75,7 @@ class wand_data_range {
             return max_score;
         }
 
-        void build(wand_data_range &wdata)
-        {
+        void build(wand_data_range &wdata) {
             wdata.m_blocks_num = blocks_num;
             wdata.m_blocks_start.steal(blocks_start);
             wdata.m_block_max_term_weight.steal(block_max_term_weight);
@@ -92,46 +83,42 @@ class wand_data_range {
                          static_cast<float>(total_elements) / wdata.m_block_max_term_weight.size());
         }
 
-        uint64_t blocks_num;
-        uint64_t total_elements;
+        uint64_t              blocks_num;
+        uint64_t              total_elements;
         std::vector<uint64_t> blocks_start;
-        std::vector<float> block_max_term_weight;
+        std::vector<float>    block_max_term_weight;
     };
 
     class enumerator {
         friend class wand_data_range;
 
        public:
-        enumerator(uint32_t _block_start,
+        enumerator(uint32_t                              _block_start,
                    mapper::mappable_vector<float> const &block_max_term_weight)
-            : cur_pos(0), block_start(_block_start), m_block_max_term_weight(block_max_term_weight)
-        {
-        }
+            : cur_pos(0),
+              block_start(_block_start),
+              m_block_max_term_weight(block_max_term_weight) {}
 
         void PISA_NOINLINE next_block() { cur_pos += 1; }
         void PISA_NOINLINE next_geq(uint64_t lower_bound) { cur_pos = lower_bound / range_size; }
         uint64_t PISA_FLATTEN_FUNC docid() const { return (cur_pos + 1) * range_size; }
 
-        float PISA_FLATTEN_FUNC score() const
-        {
+        float PISA_FLATTEN_FUNC score() const {
             return m_block_max_term_weight[block_start + cur_pos];
         }
 
        private:
-        uint64_t cur_pos;
-        uint64_t block_start;
+        uint64_t                              cur_pos;
+        uint64_t                              block_start;
         mapper::mappable_vector<float> const &m_block_max_term_weight;
     };
 
-    enumerator get_enum(uint32_t i) const
-    {
+    enumerator get_enum(uint32_t i) const {
         return enumerator(m_blocks_start[i], m_block_max_term_weight);
     }
 
-    static std::vector<bool> compute_live_blocks(std::vector<enumerator> &enums,
-                                                 float threshold,
-                                                 std::pair<uint32_t, uint32_t> document_range)
-    {
+    static std::vector<bool> compute_live_blocks(std::vector<enumerator> &enums, float threshold,
+                                                 std::pair<uint32_t, uint32_t> document_range) {
         size_t len = ceil_div((document_range.second - document_range.first), range_size);
         std::vector<bool> live_blocks(len);
         for (auto &&e : enums) {
@@ -149,16 +136,15 @@ class wand_data_range {
     }
 
     template <typename Visitor>
-    void map(Visitor &visit)
-    {
+    void map(Visitor &visit) {
         visit(m_blocks_num, "m_blocks_num")(m_blocks_start, "m_blocks_start")(
             m_block_max_term_weight, "m_block_max_term_weight");
     }
 
    private:
-    uint64_t m_blocks_num;
+    uint64_t                          m_blocks_num;
     mapper::mappable_vector<uint64_t> m_blocks_start;
-    mapper::mappable_vector<float> m_block_max_term_weight;
+    mapper::mappable_vector<float>    m_block_max_term_weight;
 };
 
-} // namespace pisa
+}  // namespace pisa

--- a/include/pisa/wand_data_raw.hpp
+++ b/include/pisa/wand_data_raw.hpp
@@ -20,34 +20,29 @@ class wand_data_raw {
 
     class builder {
        public:
-        builder(binary_freq_collection const &coll, global_parameters const &params)
-        {
+        builder(binary_freq_collection const &coll, global_parameters const &params) {
             (void)coll;
             (void)params;
             spdlog::info("Storing max weight for each list and for each block...");
             total_elements = 0;
-            total_blocks = 0;
+            total_blocks   = 0;
             effective_list = 0;
             blocks_start.push_back(0);
         }
 
         float add_sequence(binary_freq_collection::sequence const &seq,
-                           binary_freq_collection const &coll,
-                           std::vector<float> const &norm_lens,
-                           BlockSize block_size)
-        {
-
+                           binary_freq_collection const &coll, std::vector<float> const &doc_lens,
+                           float avg_len, BlockSize block_size) {
             if (seq.docs.size() > configuration::get().threshold_wand_list) {
-
                 auto t =
                     block_size.type() == typeid(FixedBlock)
-                        ? static_block_partition(
-                              seq, norm_lens, boost::get<FixedBlock>(block_size).size)
-                        : variable_block_partition(
-                              coll, seq, norm_lens, boost::get<VariableBlock>(block_size).lambda);
+                        ? static_block_partition(seq, doc_lens, avg_len,
+                                                 boost::get<FixedBlock>(block_size).size)
+                        : variable_block_partition(coll, seq, doc_lens, avg_len,
+                                                   boost::get<VariableBlock>(block_size).lambda);
 
-                block_max_term_weight.insert(
-                    block_max_term_weight.end(), t.second.begin(), t.second.end());
+                block_max_term_weight.insert(block_max_term_weight.end(), t.second.begin(),
+                                             t.second.end());
                 block_docid.insert(block_docid.end(), t.first.begin(), t.first.end());
                 max_term_weight.push_back(*(std::max_element(t.second.begin(), t.second.end())));
                 blocks_start.push_back(t.first.size() + blocks_start.back());
@@ -63,8 +58,7 @@ class wand_data_raw {
             return max_term_weight.back();
         }
 
-        void build(wand_data_raw &wdata)
-        {
+        void build(wand_data_raw &wdata) {
             wdata.m_block_max_term_weight.steal(block_max_term_weight);
             wdata.m_blocks_start.steal(blocks_start);
             wdata.m_block_docid.steal(block_docid);
@@ -72,40 +66,35 @@ class wand_data_raw {
                          static_cast<float>(total_elements) / static_cast<float>(total_blocks));
         }
 
-        uint64_t total_elements;
-        uint64_t total_blocks;
-        uint64_t effective_list;
-        std::vector<float> max_term_weight;
+        uint64_t              total_elements;
+        uint64_t              total_blocks;
+        uint64_t              effective_list;
+        std::vector<float>    max_term_weight;
         std::vector<uint64_t> blocks_start;
-        std::vector<float> block_max_term_weight;
+        std::vector<float>    block_max_term_weight;
         std::vector<uint32_t> block_docid;
     };
     class enumerator {
         friend class wand_data_raw;
 
        public:
-        enumerator(uint32_t _block_start,
-                   uint32_t _block_number,
-                   mapper::mappable_vector<float> const &max_term_weight,
+        enumerator(uint32_t _block_start, uint32_t _block_number,
+                   mapper::mappable_vector<float> const &   max_term_weight,
                    mapper::mappable_vector<uint32_t> const &block_docid)
             : cur_pos(0),
               block_start(_block_start),
               block_number(_block_number),
               m_block_max_term_weight(max_term_weight),
-              m_block_docid(block_docid)
-        {
-        }
+              m_block_docid(block_docid) {}
 
-        void PISA_NOINLINE next_geq(uint64_t lower_bound)
-        {
+        void PISA_NOINLINE next_geq(uint64_t lower_bound) {
             while (cur_pos + 1 < block_number &&
                    m_block_docid[block_start + cur_pos] < lower_bound) {
                 cur_pos++;
             }
         }
 
-        float PISA_FLATTEN_FUNC score() const
-        {
+        float PISA_FLATTEN_FUNC score() const {
             return m_block_max_term_weight[block_start + cur_pos];
         }
 
@@ -114,32 +103,28 @@ class wand_data_raw {
         uint64_t PISA_FLATTEN_FUNC find_next_skip() { return m_block_docid[cur_pos + block_start]; }
 
        private:
-        uint64_t cur_pos;
-        uint64_t block_start;
-        uint64_t block_number;
-        mapper::mappable_vector<float> const &m_block_max_term_weight;
+        uint64_t                                 cur_pos;
+        uint64_t                                 block_start;
+        uint64_t                                 block_number;
+        mapper::mappable_vector<float> const &   m_block_max_term_weight;
         mapper::mappable_vector<uint32_t> const &m_block_docid;
     };
 
-    enumerator get_enum(uint32_t i) const
-    {
-        return enumerator(m_blocks_start[i],
-                          m_blocks_start[i + 1] - m_blocks_start[i],
-                          m_block_max_term_weight,
-                          m_block_docid);
+    enumerator get_enum(uint32_t i) const {
+        return enumerator(m_blocks_start[i], m_blocks_start[i + 1] - m_blocks_start[i],
+                          m_block_max_term_weight, m_block_docid);
     }
 
     template <typename Visitor>
-    void map(Visitor &visit)
-    {
+    void map(Visitor &visit) {
         visit(m_blocks_start, "m_blocks_start")(m_block_max_term_weight, "m_block_max_term_weight")(
             m_block_docid, "m_block_docid");
     }
 
    private:
     mapper::mappable_vector<uint64_t> m_blocks_start;
-    mapper::mappable_vector<float> m_block_max_term_weight;
+    mapper::mappable_vector<float>    m_block_max_term_weight;
     mapper::mappable_vector<uint32_t> m_block_docid;
 };
 
-} // namespace pisa
+}  // namespace pisa

--- a/include/pisa/wand_data_raw.hpp
+++ b/include/pisa/wand_data_raw.hpp
@@ -20,29 +20,36 @@ class wand_data_raw {
 
     class builder {
        public:
-        builder(binary_freq_collection const &coll, global_parameters const &params) {
+        builder(binary_freq_collection const &coll, global_parameters const &params)
+        {
             (void)coll;
             (void)params;
             spdlog::info("Storing max weight for each list and for each block...");
             total_elements = 0;
-            total_blocks   = 0;
+            total_blocks = 0;
             effective_list = 0;
             blocks_start.push_back(0);
         }
 
         float add_sequence(binary_freq_collection::sequence const &seq,
-                           binary_freq_collection const &coll, std::vector<float> const &doc_lens,
-                           float avg_len, BlockSize block_size) {
+                           binary_freq_collection const &coll,
+                           std::vector<float> const &doc_lens,
+                           float avg_len,
+                           BlockSize block_size)
+        {
             if (seq.docs.size() > configuration::get().threshold_wand_list) {
                 auto t =
                     block_size.type() == typeid(FixedBlock)
-                        ? static_block_partition(seq, doc_lens, avg_len,
-                                                 boost::get<FixedBlock>(block_size).size)
-                        : variable_block_partition(coll, seq, doc_lens, avg_len,
+                        ? static_block_partition(
+                              seq, doc_lens, avg_len, boost::get<FixedBlock>(block_size).size)
+                        : variable_block_partition(coll,
+                                                   seq,
+                                                   doc_lens,
+                                                   avg_len,
                                                    boost::get<VariableBlock>(block_size).lambda);
 
-                block_max_term_weight.insert(block_max_term_weight.end(), t.second.begin(),
-                                             t.second.end());
+                block_max_term_weight.insert(
+                    block_max_term_weight.end(), t.second.begin(), t.second.end());
                 block_docid.insert(block_docid.end(), t.first.begin(), t.first.end());
                 max_term_weight.push_back(*(std::max_element(t.second.begin(), t.second.end())));
                 blocks_start.push_back(t.first.size() + blocks_start.back());
@@ -58,7 +65,8 @@ class wand_data_raw {
             return max_term_weight.back();
         }
 
-        void build(wand_data_raw &wdata) {
+        void build(wand_data_raw &wdata)
+        {
             wdata.m_block_max_term_weight.steal(block_max_term_weight);
             wdata.m_blocks_start.steal(blocks_start);
             wdata.m_block_docid.steal(block_docid);
@@ -66,35 +74,40 @@ class wand_data_raw {
                          static_cast<float>(total_elements) / static_cast<float>(total_blocks));
         }
 
-        uint64_t              total_elements;
-        uint64_t              total_blocks;
-        uint64_t              effective_list;
-        std::vector<float>    max_term_weight;
+        uint64_t total_elements;
+        uint64_t total_blocks;
+        uint64_t effective_list;
+        std::vector<float> max_term_weight;
         std::vector<uint64_t> blocks_start;
-        std::vector<float>    block_max_term_weight;
+        std::vector<float> block_max_term_weight;
         std::vector<uint32_t> block_docid;
     };
     class enumerator {
         friend class wand_data_raw;
 
        public:
-        enumerator(uint32_t _block_start, uint32_t _block_number,
-                   mapper::mappable_vector<float> const &   max_term_weight,
+        enumerator(uint32_t _block_start,
+                   uint32_t _block_number,
+                   mapper::mappable_vector<float> const &max_term_weight,
                    mapper::mappable_vector<uint32_t> const &block_docid)
             : cur_pos(0),
               block_start(_block_start),
               block_number(_block_number),
               m_block_max_term_weight(max_term_weight),
-              m_block_docid(block_docid) {}
+              m_block_docid(block_docid)
+        {
+        }
 
-        void PISA_NOINLINE next_geq(uint64_t lower_bound) {
-            while (cur_pos + 1 < block_number &&
-                   m_block_docid[block_start + cur_pos] < lower_bound) {
+        void PISA_NOINLINE next_geq(uint64_t lower_bound)
+        {
+            while (cur_pos + 1 < block_number
+                   && m_block_docid[block_start + cur_pos] < lower_bound) {
                 cur_pos++;
             }
         }
 
-        float PISA_FLATTEN_FUNC score() const {
+        float PISA_FLATTEN_FUNC score() const
+        {
             return m_block_max_term_weight[block_start + cur_pos];
         }
 
@@ -103,28 +116,32 @@ class wand_data_raw {
         uint64_t PISA_FLATTEN_FUNC find_next_skip() { return m_block_docid[cur_pos + block_start]; }
 
        private:
-        uint64_t                                 cur_pos;
-        uint64_t                                 block_start;
-        uint64_t                                 block_number;
-        mapper::mappable_vector<float> const &   m_block_max_term_weight;
+        uint64_t cur_pos;
+        uint64_t block_start;
+        uint64_t block_number;
+        mapper::mappable_vector<float> const &m_block_max_term_weight;
         mapper::mappable_vector<uint32_t> const &m_block_docid;
     };
 
-    enumerator get_enum(uint32_t i) const {
-        return enumerator(m_blocks_start[i], m_blocks_start[i + 1] - m_blocks_start[i],
-                          m_block_max_term_weight, m_block_docid);
+    enumerator get_enum(uint32_t i) const
+    {
+        return enumerator(m_blocks_start[i],
+                          m_blocks_start[i + 1] - m_blocks_start[i],
+                          m_block_max_term_weight,
+                          m_block_docid);
     }
 
     template <typename Visitor>
-    void map(Visitor &visit) {
+    void map(Visitor &visit)
+    {
         visit(m_blocks_start, "m_blocks_start")(m_block_max_term_weight, "m_block_max_term_weight")(
             m_block_docid, "m_block_docid");
     }
 
    private:
     mapper::mappable_vector<uint64_t> m_blocks_start;
-    mapper::mappable_vector<float>    m_block_max_term_weight;
+    mapper::mappable_vector<float> m_block_max_term_weight;
     mapper::mappable_vector<uint32_t> m_block_docid;
 };
 
-}  // namespace pisa
+} // namespace pisa

--- a/include/pisa/wand_data_raw.hpp
+++ b/include/pisa/wand_data_raw.hpp
@@ -33,7 +33,7 @@ class wand_data_raw {
 
         float add_sequence(binary_freq_collection::sequence const &seq,
                            binary_freq_collection const &coll,
-                           std::vector<float> const &doc_lens,
+                           std::vector<uint32_t> const &doc_lens,
                            float avg_len,
                            BlockSize block_size)
         {

--- a/include/pisa/wand_utils.hpp
+++ b/include/pisa/wand_utils.hpp
@@ -25,7 +25,8 @@ using BlockSize = boost::variant<FixedBlock, VariableBlock>;
 template <typename Scorer = bm25>
 std::pair<std::vector<uint32_t>, std::vector<float>> static_block_partition(
     binary_freq_collection::sequence const &seq,
-    std::vector<float> const &doc_lens, float avg_len,
+    std::vector<float> const &doc_lens,
+    float avg_len,
     const uint64_t block_size)
 {
     std::vector<uint32_t> block_docid;
@@ -40,7 +41,7 @@ std::pair<std::vector<uint32_t>, std::vector<float>> static_block_partition(
     for (i = 0; i < seq.docs.size(); ++i) {
         uint64_t docid = *(seq.docs.begin() + i);
         uint64_t freq = *(seq.freqs.begin() + i);
-        float score = Scorer::doc_term_weight(freq, doc_lens[docid]/avg_len);
+        float score = Scorer::doc_term_weight(freq, doc_lens[docid] / avg_len);
         max_score = std::max(max_score, score);
         if (i == 0 || (i / block_size) == current_block) {
             block_max_score = std::max(block_max_score, score);
@@ -61,7 +62,8 @@ template <typename Scorer = bm25>
 std::pair<std::vector<uint32_t>, std::vector<float>> variable_block_partition(
     binary_freq_collection const &coll,
     binary_freq_collection::sequence const &seq,
-    std::vector<float> const &doc_lens, float avg_len,
+    std::vector<float> const &doc_lens,
+    float avg_len,
     const float lambda)
 {
 
@@ -77,7 +79,7 @@ std::pair<std::vector<uint32_t>, std::vector<float>> variable_block_partition(
                    seq.freqs.begin(),
                    std::back_inserter(doc_score),
                    [&](const uint64_t &doc, const uint64_t &freq) -> doc_score_t {
-                       return {doc, Scorer::doc_term_weight(freq, doc_lens[doc]/avg_len)};
+                       return {doc, Scorer::doc_term_weight(freq, doc_lens[doc] / avg_len)};
                    });
 
     float estimated_idf = Scorer::query_term_weight(1, seq.docs.size(), coll.num_docs());

--- a/include/pisa/wand_utils.hpp
+++ b/include/pisa/wand_utils.hpp
@@ -25,7 +25,7 @@ using BlockSize = boost::variant<FixedBlock, VariableBlock>;
 template <typename Scorer = bm25>
 std::pair<std::vector<uint32_t>, std::vector<float>> static_block_partition(
     binary_freq_collection::sequence const &seq,
-    std::vector<float> const &norm_lens,
+    std::vector<float> const &doc_lens, float avg_len,
     const uint64_t block_size)
 {
     std::vector<uint32_t> block_docid;
@@ -40,7 +40,7 @@ std::pair<std::vector<uint32_t>, std::vector<float>> static_block_partition(
     for (i = 0; i < seq.docs.size(); ++i) {
         uint64_t docid = *(seq.docs.begin() + i);
         uint64_t freq = *(seq.freqs.begin() + i);
-        float score = Scorer::doc_term_weight(freq, norm_lens[docid]);
+        float score = Scorer::doc_term_weight(freq, doc_lens[docid]/avg_len);
         max_score = std::max(max_score, score);
         if (i == 0 || (i / block_size) == current_block) {
             block_max_score = std::max(block_max_score, score);
@@ -61,7 +61,7 @@ template <typename Scorer = bm25>
 std::pair<std::vector<uint32_t>, std::vector<float>> variable_block_partition(
     binary_freq_collection const &coll,
     binary_freq_collection::sequence const &seq,
-    std::vector<float> const &norm_lens,
+    std::vector<float> const &doc_lens, float avg_len,
     const float lambda)
 {
 
@@ -77,7 +77,7 @@ std::pair<std::vector<uint32_t>, std::vector<float>> variable_block_partition(
                    seq.freqs.begin(),
                    std::back_inserter(doc_score),
                    [&](const uint64_t &doc, const uint64_t &freq) -> doc_score_t {
-                       return {doc, Scorer::doc_term_weight(freq, norm_lens[doc])};
+                       return {doc, Scorer::doc_term_weight(freq, doc_lens[doc]/avg_len)};
                    });
 
     float estimated_idf = Scorer::query_term_weight(1, seq.docs.size(), coll.num_docs());

--- a/include/pisa/wand_utils.hpp
+++ b/include/pisa/wand_utils.hpp
@@ -25,7 +25,7 @@ using BlockSize = boost::variant<FixedBlock, VariableBlock>;
 template <typename Scorer = bm25>
 std::pair<std::vector<uint32_t>, std::vector<float>> static_block_partition(
     binary_freq_collection::sequence const &seq,
-    std::vector<float> const &doc_lens,
+    std::vector<uint32_t> const &doc_lens,
     float avg_len,
     const uint64_t block_size)
 {
@@ -62,7 +62,7 @@ template <typename Scorer = bm25>
 std::pair<std::vector<uint32_t>, std::vector<float>> variable_block_partition(
     binary_freq_collection const &coll,
     binary_freq_collection::sequence const &seq,
-    std::vector<float> const &doc_lens,
+    std::vector<uint32_t> const &doc_lens,
     float avg_len,
     const float lambda)
 {

--- a/test/test_wand_data.cpp
+++ b/test/test_wand_data.cpp
@@ -76,7 +76,7 @@ TEST_CASE("wand_data_range")
                 for (auto && [ pos, docid, freq ] :
                      ranges::view::zip(ranges::view::iota(0), seq.docs, seq.freqs)) {
                     float score = Scorer::doc_term_weight(
-                        freq, wdata_range.doc_len(docid) / wdata_range.avg_len());
+                        freq, wdata_range.norm_len(docid));
                     we.next_geq(docid);
                     CHECKED_ELSE(we.score() >= score)
                     {

--- a/test/test_wand_data.cpp
+++ b/test/test_wand_data.cpp
@@ -37,7 +37,7 @@ TEST_CASE("wand_data_range")
                 auto w = wdata_range.getenum(term_id);
                 for (auto && [ docid, freq ] : ranges::view::zip(seq.docs, seq.freqs)) {
                     float score = Scorer::doc_term_weight(
-                        freq, wdata_range.doc_len(docid) / wdata_range.avg_len());
+                        freq, wdata_range.norm_len(docid));
                     w.next_geq(docid);
                     CHECKED_ELSE(w.score() >= score)
                     {

--- a/test/test_wand_data.cpp
+++ b/test/test_wand_data.cpp
@@ -35,8 +35,9 @@ TEST_CASE("wand_data_range")
             if (seq.docs.size() >= 1024) {
                 auto max = wdata_range.max_term_weight(term_id);
                 auto w = wdata_range.getenum(term_id);
-                for (auto &&[docid, freq] : ranges::view::zip(seq.docs, seq.freqs)) {
-                    float score = Scorer::doc_term_weight(freq, wdata_range.doc_len(docid)/wdata_range.avg_len());
+                for (auto && [ docid, freq ] : ranges::view::zip(seq.docs, seq.freqs)) {
+                    float score = Scorer::doc_term_weight(
+                        freq, wdata_range.doc_len(docid) / wdata_range.avg_len());
                     w.next_geq(docid);
                     CHECKED_ELSE(w.score() >= score)
                     {
@@ -72,9 +73,10 @@ TEST_CASE("wand_data_range")
                 const mapper::mappable_vector<float> bm =
                     w.compute_block_max_scores(list, score_func);
                 WandTypeRange::enumerator we(0, bm);
-                for (auto &&[pos, docid, freq] :
+                for (auto && [ pos, docid, freq ] :
                      ranges::view::zip(ranges::view::iota(0), seq.docs, seq.freqs)) {
-                    float score = Scorer::doc_term_weight(freq, wdata_range.doc_len(docid)/wdata_range.avg_len());
+                    float score = Scorer::doc_term_weight(
+                        freq, wdata_range.doc_len(docid) / wdata_range.avg_len());
                     we.next_geq(docid);
                     CHECKED_ELSE(we.score() >= score)
                     {

--- a/test/test_wand_data.cpp
+++ b/test/test_wand_data.cpp
@@ -36,7 +36,7 @@ TEST_CASE("wand_data_range")
                 auto max = wdata_range.max_term_weight(term_id);
                 auto w = wdata_range.getenum(term_id);
                 for (auto &&[docid, freq] : ranges::view::zip(seq.docs, seq.freqs)) {
-                    float score = Scorer::doc_term_weight(freq, wdata_range.norm_len(docid));
+                    float score = Scorer::doc_term_weight(freq, wdata_range.doc_len(docid)/wdata_range.avg_len());
                     w.next_geq(docid);
                     CHECKED_ELSE(w.score() >= score)
                     {
@@ -74,7 +74,7 @@ TEST_CASE("wand_data_range")
                 WandTypeRange::enumerator we(0, bm);
                 for (auto &&[pos, docid, freq] :
                      ranges::view::zip(ranges::view::iota(0), seq.docs, seq.freqs)) {
-                    float score = Scorer::doc_term_weight(freq, wdata_range.norm_len(docid));
+                    float score = Scorer::doc_term_weight(freq, wdata_range.doc_len(docid)/wdata_range.avg_len());
                     we.next_geq(docid);
                     CHECKED_ELSE(we.score() >= score)
                     {


### PR DESCRIPTION
Compute `norm_lens` at run time instead of storing it precomputed. This could potentially make the BM25 scoring slightly slower, but it makes the software much more flexible as `doc_len` can be used by other scoring functions.