### PR TITLE
Update query processing

### DIFF
--- a/include/pisa/query/queries.hpp
+++ b/include/pisa/query/queries.hpp
@@ -33,7 +33,7 @@ struct Query {
     std::vector<float> term_weights;
 };
 
-[[nodiscard]] auto query_to_raw(std::string query_string, std::optional<std::string> &id)
+[[nodiscard]] auto query_to_raw(std::string const &query_string, std::optional<std::string> &id)
 {
     // query id : terms (or ids)
     auto colon = std::find(query_string.begin(), query_string.end(), ':');
@@ -91,11 +91,11 @@ struct Query {
     return {id, parsed_query, {}};
 }
 
-[[nodiscard]] std::function<void(std::string)> compute_parse_query_function(
+[[nodiscard]] std::function<void(const std::string)> compute_parse_query_function(
     std::vector<Query> &queries,
-    std::optional<std::string> terms_file,
-    std::optional<std::string> stopwords_filename,
-    std::optional<std::string> stemmer_type) {
+    const std::optional<std::string> terms_file,
+    const std::optional<std::string> stopwords_filename,
+    const std::optional<std::string> stemmer_type) {
     if (terms_file) {
         auto term_processor = TermProcessor(terms_file, stopwords_filename, stemmer_type);
         return [&](std::string const &query_line) {

--- a/include/pisa/query/queries.hpp
+++ b/include/pisa/query/queries.hpp
@@ -55,19 +55,15 @@ struct Query {
     std::vector<term_id_type> parsed_query;
     for (auto term_iter = tokenizer.begin(); term_iter != tokenizer.end(); ++term_iter) {
         auto raw_term = *term_iter;
-        try {
-            auto term = term_processor(raw_term);
-            if (term) {
-                if (!term_processor.is_stopword(*term)) {
-                    parsed_query.push_back(std::move(*term));
-                } else {
-                    spdlog::warn("Term `{}` is a stopword and will be ignored", *term);
-                }
+        auto term = term_processor(raw_term);
+        if (term) {
+            if (!term_processor.is_stopword(*term)) {
+                parsed_query.push_back(std::move(*term));
             } else {
-                spdlog::warn("Term `{}` not found and will be ignored", raw_term);
+                spdlog::warn("Term `{}` is a stopword and will be ignored", *term);
             }
-        } catch (std::invalid_argument &err) {
-            spdlog::warn("Could not parse `{}` to a number", raw_term);
+        } else {
+            spdlog::warn("Term `{}` not found and will be ignored", raw_term);
         }
     }
     return {std::move(id), std::move(parsed_query), {}};

--- a/include/pisa/query/queries.hpp
+++ b/include/pisa/query/queries.hpp
@@ -94,7 +94,7 @@ class TermProcessor {
             if (stopwords_filename) {
                 std::ifstream is(*stopwords_filename);
                 io::for_each_line(is, [&](auto &&word) {
-                    if (auto processed_term = process(std::move(word)); process) {
+                    if (auto processed_term = process(std::move(word)); processed_term.has_value()) {
                         stopwords.insert(*processed_term);
                     }
                 });
@@ -104,6 +104,14 @@ class TermProcessor {
         bool is_stopword(term_id_type term)
         {
             return stopwords.find(term) != stopwords.end();
+        }
+
+        std::vector<term_id_type> get_stopwords()
+        {
+            std::vector<term_id_type> v;
+            v.insert(v.end(), stopwords.begin(), stopwords.end());
+            sort(v.begin(), v.end());
+            return v;
         }
 };
 

--- a/include/pisa/query/queries.hpp
+++ b/include/pisa/query/queries.hpp
@@ -70,25 +70,23 @@ struct Query {
             spdlog::warn("Could not parse `{}` to a number", raw_term);
         }
     }
-    return {id, parsed_query, {}};
+    return {std::move(id), std::move(parsed_query), {}};
 }
 
 [[nodiscard]] auto parse_query_ids(std::string const &query_string) -> Query
 {
     auto [id, raw_query] = split_query_at_colon(query_string);
     std::vector<term_id_type> parsed_query;
-    std::vector<std::string> splitted_query;
-    boost::split(splitted_query, raw_query, boost::is_any_of("\t"));
+    std::vector<std::string> term_ids;
+    boost::split(term_ids, raw_query, boost::is_any_of("\t"));
     try {
-        std::transform(splitted_query.begin(),
-                       splitted_query.end(),
-                       std::back_inserter(parsed_query),
-                       [](const std::string &val) { return std::stoi(val); });
+        auto to_int = [](const std::string &val) { return std::stoi(val); };
+        std::transform(term_ids.begin(), term_ids.end(), std::back_inserter(parsed_query), to_int);
     } catch (std::invalid_argument &err) {
         spdlog::error("Could not parse term identifiers of query `{}`", raw_query);
         exit(1);
     }
-    return {id, parsed_query, {}};
+    return {std::move(id), std::move(parsed_query), {}};
 }
 
 [[nodiscard]] std::function<void(const std::string)> compute_parse_query_function(

--- a/include/pisa/query/queries.hpp
+++ b/include/pisa/query/queries.hpp
@@ -1,26 +1,20 @@
 #pragma once
 
-#include <functional>
 #include <iostream>
 #include <memory>
 #include <optional>
 #include <sstream>
 #include <string>
 #include <string_view>
-#include <unordered_map>
 
-#include <KrovetzStemmer/KrovetzStemmer.hpp>
-#include <Porter2/Porter2.hpp>
 #include <boost/algorithm/string.hpp>
-#include <mio/mmap.hpp>
 #include <range/v3/view/enumerate.hpp>
 #include <spdlog/spdlog.h>
 
 #include "index_types.hpp"
-#include "io.hpp"
-#include "payload_vector.hpp"
 #include "query/queries.hpp"
 #include "scorer/score_function.hpp"
+#include "term_processor.hpp"
 #include "tokenizer.hpp"
 #include "topk_queue.hpp"
 #include "util/util.hpp"
@@ -35,84 +29,8 @@ using term_id_vec = std::vector<term_id_type>;
 
 struct Query {
     std::optional<std::string> id;
-    std::vector<term_id_type>  terms;
-    std::vector<float>  term_weights;
-};
-
-class TermProcessor {
-    private:
-        std::unordered_set<term_id_type> stopwords;
-
-    public:
-        // Method implemented in constructor according to the specified stemmer.
-        std::function<std::optional<term_id_type>(std::string)> process;
-
-        TermProcessor(std::optional<std::string> terms_file,
-                        std::optional<std::string> stopwords_filename,
-                        std::optional<std::string> stemmer_type)
-        {
-            auto source = std::make_shared<mio::mmap_source>(terms_file->c_str());
-            auto terms = Payload_Vector<>::from(*source);
-            auto to_id = [source = std::move(source),
-            terms = std::move(terms)](auto str) -> std::optional<term_id_type>
-            {
-                auto pos = std::lower_bound(terms.begin(), terms.end(), std::string_view(str));
-                if (*pos == std::string_view(str)) {
-                    return std::distance(terms.begin(), pos);
-                }
-                return std::nullopt;
-            };
-            
-            // Implements 'process' method.
-            if (not stemmer_type) {
-                process = [=](auto str) {
-                    boost::algorithm::to_lower(str);
-                    return to_id(str);
-                };
-            }
-            else if (*stemmer_type == "porter2") {
-                process = [=](auto str) {
-                    boost::algorithm::to_lower(str);
-                    stem::Porter2 stemmer{};
-                    return to_id(stemmer.stem(str));
-                };
-            }
-            else if (*stemmer_type == "krovetz") {
-                process = [=](auto str) {
-                    boost::algorithm::to_lower(str);
-                    stem::KrovetzStemmer stemmer{};
-                    stemmer.kstem_stemmer(str);
-                    return to_id(stemmer.kstem_stemmer(str));
-                };
-            }
-            else
-            {
-                throw std::invalid_argument("Unknown stemmer");
-            }
-
-            // Loads stopwords.
-            if (stopwords_filename) {
-                std::ifstream is(*stopwords_filename);
-                io::for_each_line(is, [&](auto &&word) {
-                    if (auto processed_term = process(std::move(word)); processed_term.has_value()) {
-                        stopwords.insert(*processed_term);
-                    }
-                });
-            }
-        }
-
-        bool is_stopword(term_id_type term)
-        {
-            return stopwords.find(term) != stopwords.end();
-        }
-
-        std::vector<term_id_type> get_stopwords()
-        {
-            std::vector<term_id_type> v;
-            v.insert(v.end(), stopwords.begin(), stopwords.end());
-            sort(v.begin(), v.end());
-            return v;
-        }
+    std::vector<term_id_type> terms;
+    std::vector<float> term_weights;
 };
 
 [[nodiscard]] auto query_to_raw(std::string query_string, std::optional<std::string> &id)
@@ -127,7 +45,8 @@ class TermProcessor {
     return raw_query;
 }
 
-[[nodiscard]] auto parse_query_terms(std::string const &query_string, TermProcessor term_processor) -> Query
+[[nodiscard]] auto parse_query_terms(std::string const &query_string, TermProcessor term_processor)
+    -> Query
 {
     std::optional<std::string> id = std::nullopt;
     std::vector<term_id_type> parsed_query;
@@ -146,7 +65,7 @@ class TermProcessor {
             } else {
                 spdlog::warn("Term `{}` not found and will be ignored", raw_term);
             }
-        } catch (std::invalid_argument& err) {
+        } catch (std::invalid_argument &err) {
             spdlog::warn("Could not parse `{}` to a number", raw_term);
         }
     }
@@ -161,9 +80,11 @@ class TermProcessor {
     std::vector<std::string> splitted_query;
     boost::split(splitted_query, raw_query, boost::is_any_of("\t"));
     try {
-        std::transform(splitted_query.begin(), splitted_query.end(), std::back_inserter(parsed_query),
-            [](const std::string& val) {return std::stoi(val);});
-    } catch (std::invalid_argument& err) {
+        std::transform(splitted_query.begin(),
+                       splitted_query.end(),
+                       std::back_inserter(parsed_query),
+                       [](const std::string &val) { return std::stoi(val); });
+    } catch (std::invalid_argument &err) {
         spdlog::error("Could not parse term identifiers of query `{}`", raw_query);
         exit(1);
     }
@@ -180,15 +101,14 @@ class TermProcessor {
         return [&](std::string const &query_line) {
             queries.push_back(parse_query_terms(query_line, term_processor));
         };
-    }
-    else {
-        return [&](std::string const &query_line) {
-            queries.push_back(parse_query_ids(query_line));
-        };
+    } else {
+        return
+            [&](std::string const &query_line) { queries.push_back(parse_query_ids(query_line)); };
     }
 }
 
-bool read_query(term_id_vec &ret, std::istream &is = std::cin) {
+bool read_query(term_id_vec &ret, std::istream &is = std::cin)
+{
     ret.clear();
     std::string line;
     if (!std::getline(is, line)) {
@@ -198,15 +118,17 @@ bool read_query(term_id_vec &ret, std::istream &is = std::cin) {
     return true;
 }
 
-void remove_duplicate_terms(term_id_vec &terms) {
+void remove_duplicate_terms(term_id_vec &terms)
+{
     std::sort(terms.begin(), terms.end());
     terms.erase(std::unique(terms.begin(), terms.end()), terms.end());
 }
 
 typedef std::pair<uint64_t, uint64_t> term_freq_pair;
-typedef std::vector<term_freq_pair>   term_freq_vec;
+typedef std::vector<term_freq_pair> term_freq_vec;
 
-term_freq_vec query_freqs(term_id_vec terms) {
+term_freq_vec query_freqs(term_id_vec terms)
+{
     term_freq_vec query_term_freqs;
     std::sort(terms.begin(), terms.end());
     // count query term frequencies

--- a/include/pisa/query/queries.hpp
+++ b/include/pisa/query/queries.hpp
@@ -78,7 +78,12 @@ struct Query {
     auto [id, raw_query] = split_query_at_colon(query_string);
     std::vector<term_id_type> parsed_query;
     std::vector<std::string> term_ids;
-    boost::split(term_ids, raw_query, boost::is_any_of("\t"));
+    boost::split(term_ids, raw_query, boost::is_any_of("\t, ,\v,\f,\r,\n"));
+
+    auto is_empty = [](const std::string &val) { return val.empty(); };
+    // remove_if move matching elements to the end, preparing them for erase.
+    term_ids.erase(std::remove_if(term_ids.begin(), term_ids.end(), is_empty), term_ids.end());
+
     try {
         auto to_int = [](const std::string &val) { return std::stoi(val); };
         std::transform(term_ids.begin(), term_ids.end(), std::back_inserter(parsed_query), to_int);

--- a/include/pisa/query/queries.hpp
+++ b/include/pisa/query/queries.hpp
@@ -56,7 +56,7 @@ struct Query {
     for (auto term_iter = tokenizer.begin(); term_iter != tokenizer.end(); ++term_iter) {
         auto raw_term = *term_iter;
         try {
-            auto term = term_processor.process(std::string(raw_term));
+            auto term = term_processor(raw_term);
             if (term) {
                 if (!term_processor.is_stopword(*term)) {
                     parsed_query.push_back(std::move(*term));

--- a/include/pisa/query/term_processor.hpp
+++ b/include/pisa/query/term_processor.hpp
@@ -44,20 +44,20 @@ class TermProcessor {
         if (not stemmer_type) {
             _to_id = [=](auto str) {
                 boost::algorithm::to_lower(str);
-                return to_id(str);
+                return to_id(std::move(str));
             };
         } else if (*stemmer_type == "porter2") {
             _to_id = [=](auto str) {
                 boost::algorithm::to_lower(str);
                 stem::Porter2 stemmer{};
-                return to_id(stemmer.stem(str));
+                return to_id(std::move(stemmer.stem(str)));
             };
         } else if (*stemmer_type == "krovetz") {
             _to_id = [=](auto str) {
                 boost::algorithm::to_lower(str);
                 stem::KrovetzStemmer stemmer{};
                 stemmer.kstem_stemmer(str);
-                return to_id(stemmer.kstem_stemmer(str));
+                return to_id(stemmer.kstem_stemmer(std::move(str)));
             };
         } else {
             throw std::invalid_argument("Unknown stemmer");

--- a/include/pisa/query/term_processor.hpp
+++ b/include/pisa/query/term_processor.hpp
@@ -24,9 +24,9 @@ class TermProcessor {
     // Method implemented in constructor according to the specified stemmer.
     std::function<std::optional<term_id_type>(std::string)> process;
 
-    TermProcessor(std::optional<std::string> terms_file,
-                  std::optional<std::string> stopwords_filename,
-                  std::optional<std::string> stemmer_type)
+    TermProcessor(const std::optional<std::string> terms_file,
+                  const std::optional<std::string> stopwords_filename,
+                  const std::optional<std::string> stemmer_type)
     {
         auto source = std::make_shared<mio::mmap_source>(terms_file->c_str());
         auto terms = Payload_Vector<>::from(*source);
@@ -74,7 +74,7 @@ class TermProcessor {
         }
     }
 
-    bool is_stopword(term_id_type term) { return stopwords.find(term) != stopwords.end(); }
+    bool is_stopword(const term_id_type term) { return stopwords.find(term) != stopwords.end(); }
 
     std::vector<term_id_type> get_stopwords()
     {

--- a/include/pisa/query/term_processor.hpp
+++ b/include/pisa/query/term_processor.hpp
@@ -1,0 +1,87 @@
+#pragma once
+
+#include <functional>
+#include <optional>
+#include <unordered_set>
+
+#include <KrovetzStemmer/KrovetzStemmer.hpp>
+#include <Porter2/Porter2.hpp>
+#include <boost/algorithm/string.hpp>
+#include <mio/mmap.hpp>
+
+#include "io.hpp"
+#include "payload_vector.hpp"
+
+namespace pisa {
+
+using term_id_type = uint32_t;
+
+class TermProcessor {
+   private:
+    std::unordered_set<term_id_type> stopwords;
+
+   public:
+    // Method implemented in constructor according to the specified stemmer.
+    std::function<std::optional<term_id_type>(std::string)> process;
+
+    TermProcessor(std::optional<std::string> terms_file,
+                  std::optional<std::string> stopwords_filename,
+                  std::optional<std::string> stemmer_type)
+    {
+        auto source = std::make_shared<mio::mmap_source>(terms_file->c_str());
+        auto terms = Payload_Vector<>::from(*source);
+        auto to_id = [source = std::move(source),
+                      terms = std::move(terms)](auto str) -> std::optional<term_id_type> {
+            // Note: the lexicographical order of the terms matters.
+            auto pos = std::lower_bound(terms.begin(), terms.end(), std::string_view(str));
+            if (*pos == std::string_view(str)) {
+                return std::distance(terms.begin(), pos);
+            }
+            return std::nullopt;
+        };
+
+        // Implements 'process' method.
+        if (not stemmer_type) {
+            process = [=](auto str) {
+                boost::algorithm::to_lower(str);
+                return to_id(str);
+            };
+        } else if (*stemmer_type == "porter2") {
+            process = [=](auto str) {
+                boost::algorithm::to_lower(str);
+                stem::Porter2 stemmer{};
+                return to_id(stemmer.stem(str));
+            };
+        } else if (*stemmer_type == "krovetz") {
+            process = [=](auto str) {
+                boost::algorithm::to_lower(str);
+                stem::KrovetzStemmer stemmer{};
+                stemmer.kstem_stemmer(str);
+                return to_id(stemmer.kstem_stemmer(str));
+            };
+        } else {
+            throw std::invalid_argument("Unknown stemmer");
+        }
+
+        // Loads stopwords.
+        if (stopwords_filename) {
+            std::ifstream is(*stopwords_filename);
+            io::for_each_line(is, [&](auto &&word) {
+                if (auto processed_term = process(std::move(word)); processed_term.has_value()) {
+                    stopwords.insert(*processed_term);
+                }
+            });
+        }
+    }
+
+    bool is_stopword(term_id_type term) { return stopwords.find(term) != stopwords.end(); }
+
+    std::vector<term_id_type> get_stopwords()
+    {
+        std::vector<term_id_type> v;
+        v.insert(v.end(), stopwords.begin(), stopwords.end());
+        sort(v.begin(), v.end());
+        return v;
+    }
+};
+} // namespace pisa

--- a/src/compute_intersection.cpp
+++ b/src/compute_intersection.cpp
@@ -64,11 +64,9 @@ int main(int argc, const char **argv)
     app.add_flag("--compressed-wand", compressed, "Compressed wand input file");
     CLI11_PARSE(app, argc, argv);
 
-    auto process_term = query::term_processor(terms_file, std::nullopt);
-
     std::vector<Query> queries;
     auto push_query = [&](std::string const &query_line) {
-        queries.push_back(parse_query(query_line, process_term));
+        queries.push_back(parse_query_ids(query_line));
     };
 
     if (query_filename) {

--- a/src/evaluate_queries.cpp
+++ b/src/evaluate_queries.cpp
@@ -186,9 +186,9 @@ int main(int argc, const char **argv)
     app.add_option("-r,--run", run_id, "Run identifier");
     app.add_option("--threads", threads, "Thread Count");
     app.add_flag("--compressed-wand", compressed, "Compressed wand input file");
-    app.add_option("--stopwords", stopwords_filename, "File containing stopwords to ignore");
     app.add_option("-k", k, "k value");
     auto *terms_opt = app.add_option("--terms", terms_file, "Term lexicon");
+    app.add_option("--stopwords", stopwords_filename, "File containing stopwords to ignore")->needs(terms_opt);
     app.add_option("--stemmer", stemmer, "Stemmer type")->needs(terms_opt);
     app.add_option("--documents", documents_file, "Document lexicon")->required();
     CLI11_PARSE(app, argc, argv);

--- a/src/evaluate_queries.cpp
+++ b/src/evaluate_queries.cpp
@@ -196,25 +196,13 @@ int main(int argc, const char **argv)
     tbb::task_scheduler_init init(threads);
     spdlog::info("Number of threads: {}", threads);
 
-    std::vector<Query> queries;
-    auto process_term = query::term_processor(terms_file, stemmer);
-
-    std::unordered_set<term_id_type> stopwords;
-    if (stopwords_filename) {
-        std::ifstream is(*stopwords_filename);
-        io::for_each_line(is, [&](auto &&word) {
-            if (auto processed_term = process_term(std::move(word)); process_term) {
-                stopwords.insert(*processed_term);
-            }
-        });
-    }
-
     if (run_id.empty())
         run_id = "R0";
 
-    auto push_query = [&](std::string const &query_line) {
-        queries.push_back(parse_query(query_line, process_term, stopwords));
-    };
+    std::vector<Query> queries;
+    auto push_query = compute_parse_query_function(queries, terms_file,
+                                                   stopwords_filename,
+                                                   stemmer);
 
     if (query_filename) {
         std::ifstream is(*query_filename);

--- a/src/queries.cpp
+++ b/src/queries.cpp
@@ -273,33 +273,19 @@ int main(int argc, const char **argv)
     } else {
         spdlog::set_default_logger(spdlog::stderr_color_mt("stderr"));
     }
-
-    auto process_term = query::term_processor(terms_file, stemmer);
-
-    std::unordered_set<term_id_type> stopwords;
-    if (stopwords_filename) {
-        std::ifstream is(*stopwords_filename);
-        io::for_each_line(is, [&](auto &&word) {
-            if (auto processed_term = process_term(std::move(word)); process_term) {
-                stopwords.insert(*processed_term);
-            }
-        });
-    }
-
-    std::vector<Query> queries;
-    auto push_query = [&](std::string const &query_line) {
-        queries.push_back(parse_query(query_line, process_term, stopwords));
-    };
-
     if (extract) {
         std::cout << "qid\tusec\n";
     }
 
+    std::vector<Query> queries;
+    auto parse_query = compute_parse_query_function(queries, terms_file,
+                                                    stopwords_filename,
+                                                    stemmer);
     if (query_filename) {
         std::ifstream is(*query_filename);
-        io::for_each_line(is, push_query);
+        io::for_each_line(is, parse_query);
     } else {
-        io::for_each_line(std::cin, push_query);
+        io::for_each_line(std::cin, parse_query);
     }
 
     /**/

--- a/src/queries.cpp
+++ b/src/queries.cpp
@@ -260,9 +260,9 @@ int main(int argc, const char **argv)
     app.add_option("-q,--query", query_filename, "Queries filename");
     app.add_flag("--compressed-wand", compressed, "Compressed wand input file");
     app.add_option("-k", k, "k value");
-    app.add_option("--stopwords", stopwords_filename, "File containing stopwords to ignore");
     app.add_option("-T,--thresholds", thresholds_filename, "k value");
     auto *terms_opt = app.add_option("--terms", terms_file, "Term lexicon");
+    app.add_option("--stopwords", stopwords_filename, "File containing stopwords to ignore")->needs(terms_opt);
     app.add_option("--stemmer", stemmer, "Stemmer type")->needs(terms_opt);
     app.add_flag("--extract", extract, "Extract individual query times");
     app.add_flag("--silent", silent, "Suppress logging");

--- a/src/thresholds.cpp
+++ b/src/thresholds.cpp
@@ -87,17 +87,15 @@ int main(int argc, const char **argv)
     app.add_option("--stemmer", stemmer, "Stemmer type")->needs(terms_opt);
     CLI11_PARSE(app, argc, argv);
 
-    auto process_term = query::term_processor(terms_file, stemmer);
-
     std::vector<Query> queries;
-    auto push_query = [&](std::string const &query_line) {
-        queries.push_back(parse_query(query_line, process_term));
-    };
+    auto parse_query = compute_parse_query_function(queries, terms_file,
+                                                    std::nullopt,
+                                                    stemmer);
     if (query_filename) {
         std::ifstream is(*query_filename);
-        io::for_each_line(is, push_query);
+        io::for_each_line(is, parse_query);
     } else {
-        io::for_each_line(std::cin, push_query);
+        io::for_each_line(std::cin, parse_query);
     }
 
     /**/

--- a/test/test_bmw_queries.cpp
+++ b/test/test_bmw_queries.cpp
@@ -36,13 +36,10 @@ struct IndexData {
                 plist.docs.size(), plist.docs.begin(), plist.freqs.begin(), freqs_sum);
         }
         builder.build(index);
-
-        auto process_term = [](auto str) { return std::stoi(str); };
-
         term_id_vec q;
         std::ifstream qfile(PISA_SOURCE_DIR "/test/test_data/queries");
         auto push_query = [&](std::string const &query_line) {
-            queries.push_back(parse_query(query_line, process_term, {}));
+            queries.push_back(parse_query_ids(query_line));
         };
         io::for_each_line(qfile, push_query);
     }

--- a/test/test_queries.cpp
+++ b/test/test_queries.cpp
@@ -21,3 +21,57 @@ TEST_CASE("Parse query term ids with query id") {
     REQUIRE(q.id == "1");
     REQUIRE(q.terms == std::vector<std::uint32_t>{1, 2, 3, 4});
 }
+
+TEST_CASE("Load stopwords in term processor with all stopwords present in the lexicon") {
+    Temporary_Directory tmpdir;
+    auto lexfile = tmpdir.path() / "lex";
+    encode_payload_vector(
+        gsl::make_span(std::vector<std::string>{"a", "account", "he", "she", "usa", "world"}))
+        .to_file(lexfile.string());
+
+    auto stopwords_filename = (tmpdir.path() / "stopwords").string();
+    std::ofstream is(stopwords_filename);
+    is << "a\nshe\nhe";
+    is.close();
+
+    TermProcessor tprocessor(std::make_optional(lexfile.string()), std::make_optional(stopwords_filename), std::nullopt);
+    REQUIRE(tprocessor.get_stopwords() == std::vector<std::uint32_t>{0, 2, 3});
+}
+
+TEST_CASE("Load stopwords in term processor with some stopwords not present in the lexicon") {
+    Temporary_Directory tmpdir;
+    auto lexfile = tmpdir.path() / "lex";
+    encode_payload_vector(
+        gsl::make_span(std::vector<std::string>{"account", "coffee", "he", "she", "usa", "world"}))
+        .to_file(lexfile.string());
+
+    auto stopwords_filename = (tmpdir.path() / "stopwords").string();
+    std::ofstream is(stopwords_filename);
+    is << "\nis\nto\na\nshe\nhe";
+    is.close();
+
+    TermProcessor tprocessor(std::make_optional(lexfile.string()), std::make_optional(stopwords_filename), std::nullopt);
+    REQUIRE(tprocessor.get_stopwords() == std::vector<std::uint32_t>{2, 3});
+}
+
+TEST_CASE("Check if term is stopword")
+{
+    Temporary_Directory tmpdir;
+    auto lexfile = tmpdir.path() / "lex";
+    encode_payload_vector(
+        gsl::make_span(std::vector<std::string>{"account", "coffee", "he", "she", "usa", "world"}))
+        .to_file(lexfile.string());
+
+    auto stopwords_filename = (tmpdir.path() / "stopwords").string();
+    std::ofstream is(stopwords_filename);
+    is << "\nis\nto\na\nshe\nhe";
+    is.close();
+
+    TermProcessor tprocessor(std::make_optional(lexfile.string()), std::make_optional(stopwords_filename), std::nullopt);
+    REQUIRE(!tprocessor.is_stopword(0));
+    REQUIRE(!tprocessor.is_stopword(1));
+    REQUIRE(tprocessor.is_stopword(2));
+    REQUIRE(tprocessor.is_stopword(3));
+    REQUIRE(!tprocessor.is_stopword(4));
+    REQUIRE(!tprocessor.is_stopword(5));
+}

--- a/test/test_queries.cpp
+++ b/test/test_queries.cpp
@@ -7,7 +7,7 @@
 using namespace pisa;
 
 TEST_CASE("Parse query term ids without query id") {
-    auto raw_query = "1\t2\t3\t4";
+    auto raw_query = "1 2\t3    4";
     std::optional<std::string> id = std::nullopt;
     auto q = parse_query_ids(raw_query);
     REQUIRE(q.id.has_value() == false);
@@ -15,7 +15,7 @@ TEST_CASE("Parse query term ids without query id") {
 }
 
 TEST_CASE("Parse query term ids with query id") {
-    auto raw_query = "1: 1\t2\t3\t4";
+    auto raw_query = "1: 1\t2 3\t4";
     std::optional<std::string> id = std::nullopt;
     auto q = parse_query_ids(raw_query);
     REQUIRE(q.id == "1");

--- a/test/test_queries.cpp
+++ b/test/test_queries.cpp
@@ -1,0 +1,23 @@
+#define CATCH_CONFIG_MAIN
+
+#include <catch2/catch.hpp>
+#include "query/queries.hpp"
+#include "temporary_directory.hpp"
+
+using namespace pisa;
+
+TEST_CASE("Parse query term ids without query id") {
+    auto raw_query = "1\t2\t3\t4";
+    std::optional<std::string> id = std::nullopt;
+    auto q = parse_query_ids(raw_query);
+    REQUIRE(q.id.has_value() == false);
+    REQUIRE(q.terms == std::vector<std::uint32_t>{1, 2, 3, 4});
+}
+
+TEST_CASE("Parse query term ids with query id") {
+    auto raw_query = "1: 1\t2\t3\t4";
+    std::optional<std::string> id = std::nullopt;
+    auto q = parse_query_ids(raw_query);
+    REQUIRE(q.id == "1");
+    REQUIRE(q.terms == std::vector<std::uint32_t>{1, 2, 3, 4});
+}

--- a/test/test_ranked_queries.cpp
+++ b/test/test_ranked_queries.cpp
@@ -38,12 +38,10 @@ struct IndexData {
         }
         builder.build(index);
 
-        auto process_term = [](auto str) { return std::stoi(str); };
-
         term_id_vec q;
         std::ifstream qfile(PISA_SOURCE_DIR "/test/test_data/queries");
         auto push_query = [&](std::string const &query_line) {
-            queries.push_back(parse_query(query_line, process_term, {}));
+            queries.push_back(parse_query_ids(query_line));
         };
         io::for_each_line(qfile, push_query);
 

--- a/test/test_tokenizer.cpp
+++ b/test/test_tokenizer.cpp
@@ -38,9 +38,8 @@ TEST_CASE("Parse query terms to ids") {
              {"lol's", std::nullopt, {0}},
              {"U.S.A.!?", std::nullopt, {4}}}));
     CAPTURE(query);
-    TermProcessor process_term =
-        query::term_processor(std::make_optional(lexfile.string()), "krovetz");
-    auto q = parse_query(query, process_term);
+    TermProcessor term_processor(std::make_optional(lexfile.string()), std::nullopt, "krovetz");
+    auto q = parse_query_terms(query, term_processor);
     REQUIRE(q.id == id);
     REQUIRE(q.terms == parsed);
 }


### PR DESCRIPTION
Changes proposed in this pull request:
- Refactor queries.hpp to avoid tokenization when using query ids
- Make the 'stopwords' parameter require 'terms' option
- Fix term existence checking when stopwords are load in term processor