### PR TITLE
Fix TBB leaks in tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 **/.DS_Store
 
-build/
+build*/
 data/
 debug/
 pisa_config.hpp
@@ -23,3 +23,5 @@ Testing/
 docs/_build/
 
 node_modules
+
+.clangd/

--- a/test/test_forward_index_builder.cpp
+++ b/test/test_forward_index_builder.cpp
@@ -167,7 +167,7 @@ void write_batch(std::string const &basename,
 
 TEST_CASE("Merge forward index batches", "[parsing][forward_index]")
 {
-    tbb::task_scheduler_init init(2);
+    tbb::task_scheduler_init init;
     Temporary_Directory tmpdir;
     auto dir = tmpdir.path();
     GIVEN("Three batches on disk")
@@ -314,7 +314,7 @@ TEST_CASE("Parse HTML content", "[parsing][forward_index][unit]")
 
 TEST_CASE("Build forward index", "[parsing][forward_index][integration]")
 {
-    tbb::task_scheduler_init init(2);
+    tbb::task_scheduler_init init;
     auto next_record = [](std::istream &in) -> std::optional<Document_Record> {
         Plaintext_Record record;
         if (in >> record) {

--- a/test/test_invert.cpp
+++ b/test/test_invert.cpp
@@ -126,7 +126,7 @@ TEST_CASE("Accumulate postings to Inverted_Index one by one", "[invert][unit]")
 
 TEST_CASE("Join Inverted_Index to another", "[invert][unit]")
 {
-    tbb::task_scheduler_init init(2);
+    tbb::task_scheduler_init init;
     auto [lhs, rhs, expected_joined, message] =
         GENERATE(table<index_type, index_type, index_type, std::string>(
             {{index_type({{0_t, {0_d, 1_d, 2_d}}, {1_t, {0_d, 1_d}}, {2_t, {5_d}}},
@@ -196,7 +196,7 @@ TEST_CASE("Join Inverted_Index to another", "[invert][unit]")
 
 TEST_CASE("Invert a range of documents from a collection", "[invert][unit]")
 {
-    tbb::task_scheduler_init init(2);
+    tbb::task_scheduler_init init;
     std::vector<std::vector<Term_Id>> collection = {
         /* Doc 0 */ {2_t, 0_t, 3_t, 9_t, 0_t},
         /* Doc 1 */ {5_t, 0_t, 3_t, 4_t, 2_t, 6_t, 7_t, 4_t, 5_t},
@@ -241,7 +241,7 @@ TEST_CASE("Invert a range of documents from a collection", "[invert][unit]")
 
 TEST_CASE("Invert collection", "[invert][unit]")
 {
-    tbb::task_scheduler_init init(2);
+    tbb::task_scheduler_init init;
     GIVEN("A binary collection")
     {
         Temporary_Directory tmpdir;

--- a/test/test_ranked_queries.cpp
+++ b/test/test_ranked_queries.cpp
@@ -31,7 +31,7 @@ struct IndexData {
                 BlockSize(FixedBlock()))
 
     {
-        tbb::task_scheduler_init init(1);
+        tbb::task_scheduler_init init;
         typename Index::builder builder(collection.num_docs(), params);
         for (auto const &plist : collection) {
             uint64_t freqs_sum =

--- a/test/test_ranked_queries.cpp
+++ b/test/test_ranked_queries.cpp
@@ -3,6 +3,8 @@
 #include <catch2/catch.hpp>
 #include <functional>
 
+#include <tbb/task_scheduler_init.h>
+
 #include "test_common.hpp"
 
 #include "accumulator/lazy_accumulator.hpp"
@@ -29,6 +31,7 @@ struct IndexData {
                 BlockSize(FixedBlock()))
 
     {
+        tbb::task_scheduler_init init(1);
         typename Index::builder builder(collection.num_docs(), params);
         for (auto const &plist : collection) {
             uint64_t freqs_sum =
@@ -121,8 +124,8 @@ TEMPLATE_TEST_CASE("Ranked query test",
         op_q(make_block_max_scored_cursors(data->index, data->wdata, q), data->index.num_docs());
         REQUIRE(or_q.topk().size() == op_q.topk().size());
         for (size_t i = 0; i < or_q.topk().size(); ++i) {
-            REQUIRE(or_q.topk()[i].first ==
-                    Approx(op_q.topk()[i].first).epsilon(0.1)); // tolerance is % relative
+            REQUIRE(or_q.topk()[i].first
+                    == Approx(op_q.topk()[i].first).epsilon(0.1)); // tolerance is % relative
         }
     }
 }
@@ -140,8 +143,8 @@ TEMPLATE_TEST_CASE("Ranked AND query test",
         op_q(make_block_max_scored_cursors(data->index, data->wdata, q), data->index.num_docs());
         REQUIRE(and_q.topk().size() == op_q.topk().size());
         for (size_t i = 0; i < and_q.topk().size(); ++i) {
-            REQUIRE(and_q.topk()[i].first ==
-                    Approx(op_q.topk()[i].first).epsilon(0.1)); // tolerance is % relative
+            REQUIRE(and_q.topk()[i].first
+                    == Approx(op_q.topk()[i].first).epsilon(0.1)); // tolerance is % relative
         }
     }
 }

--- a/test/test_wand_data.cpp
+++ b/test/test_wand_data.cpp
@@ -18,7 +18,7 @@ using namespace pisa;
 
 TEST_CASE("wand_data_range")
 {
-    tbb::task_scheduler_init init(2);
+    tbb::task_scheduler_init init;
     using WandTypeRange = wand_data_range<64, 1024, bm25>;
     using WandType = wand_data<WandTypeRange>;
     using Scorer = bm25;

--- a/test/test_wand_data.cpp
+++ b/test/test_wand_data.cpp
@@ -4,6 +4,7 @@
 #include <functional>
 
 #include <range/v3/view/enumerate.hpp>
+#include <tbb/task_scheduler_init.h>
 
 #include "test_common.hpp"
 
@@ -17,6 +18,7 @@ using namespace pisa;
 
 TEST_CASE("wand_data_range")
 {
+    tbb::task_scheduler_init init(2);
     using WandTypeRange = wand_data_range<64, 1024, bm25>;
     using WandType = wand_data<WandTypeRange>;
     using Scorer = bm25;
@@ -35,9 +37,8 @@ TEST_CASE("wand_data_range")
             if (seq.docs.size() >= 1024) {
                 auto max = wdata_range.max_term_weight(term_id);
                 auto w = wdata_range.getenum(term_id);
-                for (auto && [ docid, freq ] : ranges::view::zip(seq.docs, seq.freqs)) {
-                    float score = Scorer::doc_term_weight(
-                        freq, wdata_range.norm_len(docid));
+                for (auto &&[docid, freq] : ranges::view::zip(seq.docs, seq.freqs)) {
+                    float score = Scorer::doc_term_weight(freq, wdata_range.norm_len(docid));
                     w.next_geq(docid);
                     CHECKED_ELSE(w.score() >= score)
                     {
@@ -73,10 +74,9 @@ TEST_CASE("wand_data_range")
                 const mapper::mappable_vector<float> bm =
                     w.compute_block_max_scores(list, score_func);
                 WandTypeRange::enumerator we(0, bm);
-                for (auto && [ pos, docid, freq ] :
+                for (auto &&[pos, docid, freq] :
                      ranges::view::zip(ranges::view::iota(0), seq.docs, seq.freqs)) {
-                    float score = Scorer::doc_term_weight(
-                        freq, wdata_range.norm_len(docid));
+                    float score = Scorer::doc_term_weight(freq, wdata_range.norm_len(docid));
                     we.next_geq(docid);
                     CHECKED_ELSE(we.score() >= score)
                     {


### PR DESCRIPTION
Fixes #265

There are still other problems that the sanitizer finds in the following tests:
```
The following tests FAILED:
	  5 - test_block_codecs:block_codecs (Failed)
	  9 - test_bmw_queries:block_max_wand (Failed)
	 25 - test_freq_index:freq_index (Failed)
	 43 - test_partition_fwd_index:copy_sequence (Failed)
	 44 - test_partition_fwd_index:Rearrange sequences (Failed)
	 46 - test_partitioned_sequence:partitioned_sequence (Failed)
	 54 - test_positive_sequence:positive_sequence (Failed)
```

Likely some of them (or all) are related to the problems clang static analyzer found: #263