### PR TITLE
clang-tidy cmake support

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -34,7 +34,7 @@ PenaltyBreakFirstLessLess: 20
 PenaltyBreakString: 1000
 PenaltyExcessCharacter: 1000000
 PenaltyReturnTypeOnItsOwnLine: 200
-PointerAlignment: Right
+PointerAlignment: Left
 SpaceAfterControlStatementKeyword: true
 SpaceBeforeAssignmentOperators: true
 SpaceInEmptyParentheses: false

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,19 @@
+---
+WarningsAsErrors: '1'
+HeaderFilterRegex: '.*include/pisa.*\.hpp'
+FormatStyle: none
+Checks: |
+    *,
+    -llvm-*,
+    -google-*,
+    -fuchsia-*,
+    -zircon-*,
+    -abseil-*,
+    -clang-diagnostic-c++17-extensions,
+    -cppcoreguidelines-pro-type-reinterpret-cast,
+    -clang-diagnostic-error,
+    -cppcoreguidelines-pro-bounds-pointer-arithmetic,
+    -cppcoreguidelines-avoid-magic-numbers,
+    -cppcoreguidelines-pro-bounds-array-to-pointer-decay,
+    -modernize-use-trailing-return-type,
+    -readability-magic-numbers

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,7 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 option(PISA_BUILD_TOOLS "Build command line tools." ON)
 option(PISA_ENABLE_TESTING "Enable testing of the library." ON)
 option(PISA_ENABLE_BENCHMARKING "Enable benchmarking of the library." ON)
+option(PISA_ENABLE_CLANG_TIDY "Enable static analysis with clang-tidy" OFF)
 
 configure_file(
   ${PISA_SOURCE_DIR}/include/pisa/pisa_config.hpp.in
@@ -74,6 +75,15 @@ find_package(Threads REQUIRED)
 file(GLOB_RECURSE PISA_SRC_FILES FOLLOW_SYMLINKS "src/*cpp")
 list(SORT PISA_SRC_FILES)
 
+if (PISA_ENABLE_CLANG_TIDY)
+    find_program(CLANGTIDY clang-tidy-9)
+    if(CLANGTIDY)
+        set(CMAKE_CXX_CLANG_TIDY ${CLANGTIDY})
+    else()
+        message(SEND_ERROR "clang-tidy requested but executable not found")
+    endif()
+endif()
+
 include_directories(include)
 add_library(pisa ${PISA_SRC_FILES})
 target_include_directories(pisa PUBLIC
@@ -115,7 +125,6 @@ endif()
 if (PISA_ENABLE_BENCHMARKING)
   add_subdirectory(benchmarks)
 endif()
-
 
 if(PISA_COMPILE_HEADERS)
   get_property(PISA_INTERFACE_INCLUDE_DIRECTORIES TARGET pisa PROPERTY INTERFACE_INCLUDE_DIRECTORIES)

--- a/include/pisa/index.hpp
+++ b/include/pisa/index.hpp
@@ -1,0 +1,132 @@
+#pragma once
+
+#include <any>
+#include <optional>
+
+#include <gsl/span>
+
+#include "index_metadata.hpp"
+
+namespace pisa {
+
+using DocId = std::uint32_t;
+using TermId = std::uint32_t;
+
+using OffsetSpan = gsl::span<std::size_t const>;
+using BinarySpan = gsl::span<std::byte const>;
+
+template <typename Cursor>
+class Reader;
+
+/// Note that offsets is stored here uncompressed.
+/// For compressed, this needs to be slightly modified but the general idea is the same.
+/// We'll need something that can get offsets for posting lists.
+struct PostingData {
+    BinarySpan postings;
+    OffsetSpan offsets;
+};
+
+class Index {
+   public:
+    template <typename Source>
+    Index(gsl::span<std::uint32_t const> document_lengths, float avg_document_length, Source source)
+        : m_document_lengths(document_lengths),
+          m_avg_document_length(avg_document_length),
+          m_source(std::move(source))
+    {
+    }
+    [[nodiscard]] auto num_terms() const -> std::size_t;
+    [[nodiscard]] auto num_documents() const -> std::size_t;
+    [[nodiscard]] auto document_length(DocId docid) const -> std::uint32_t;
+    [[nodiscard]] auto avg_document_length() const -> float;
+    [[nodiscard]] auto normalized_document_length(DocId docid) const -> float;
+
+   protected:
+    [[nodiscard]] auto fetch_postings(TermId term, PostingData const& data) const
+        -> gsl::span<std::byte const>;
+
+   private:
+    gsl::span<std::uint32_t const> m_document_lengths;
+    float m_avg_document_length;
+    std::any m_source;
+};
+
+template <typename DocumentBlockEncoding>
+class SaatCursor;
+
+template <typename DocumentBlockEncoding>
+class SaatIndex {
+   public:
+    SaatIndex() = default;
+    [[nodiscard]] auto cursor(TermId term) const -> SaatCursor<DocumentBlockEncoding>
+    {
+        return m_posting_reader.read(this->fetch_postings(term, m_postings));
+    }
+
+   private:
+    PostingData m_postings;
+    Reader<SaatCursor<DocumentBlockEncoding>> m_posting_reader;
+};
+
+/// Your typical block-encoded postings.
+template <typename BlockEncoding>
+class BlockCursor;
+
+/// Documents zipped with payloads like frequencies or scores.
+template <typename DocumentCursor, typename PayloadCursor>
+class DocumentPayloadCursor;
+
+/// Cursor that scores frequency postings at query time.
+template <typename Scorer>
+class ScoringCursor;
+
+enum class MaxScoreType { MaxScore, BlockMaxScore };
+
+/// A "fake" scorer that will indicate to take quantized scores.
+struct QuantizedScorer {
+    config::Scorer scorer;
+};
+
+struct Bm25Scorer {
+    // TODO: all the other stuff needed.
+    config::Scorer scorer;
+};
+
+template <typename DocumentCursor, typename FrequencyCursor, typename ScoreCursor>
+class DaatIndex {
+   public:
+    DaatIndex() = default;
+
+    [[nodiscard]] auto documents(TermId term) const -> DocumentCursor
+    {
+        return m_document_reader.read(this->fetch_postings(term, m_documents));
+    }
+
+    [[nodiscard]] auto frequencies(TermId term) const -> FrequencyCursor
+    {
+        return m_frequency_reader.read(this->fetch_postings(term, m_frequencies));
+    }
+
+    [[nodiscard]] auto quantized_scores(config::Scorer scorer, TermId term) const -> ScoreCursor
+    {
+        return m_score_readers.at(scorer).read(this->fetch_postings(term, m_scores.at(scorer)));
+    }
+
+    [[nodiscard]] auto frequency_postings(TermId term) const;
+
+    template <typename Scorer>
+    [[nodiscard]] auto scored_postings(
+        TermId term,
+        Scorer scorer,
+        std::optional<MaxScoreType> max_score_type = std::nullopt) const;
+
+   private:
+    PostingData m_documents;
+    PostingData m_frequencies;
+    std::map<config::Scorer, PostingData> m_scores;
+    Reader<DocumentCursor> m_document_reader;
+    Reader<FrequencyCursor> m_frequency_reader;
+    std::map<config::Scorer, Reader<ScoreCursor>> m_score_readers;
+};
+
+} // namespace pisa

--- a/include/pisa/index_metadata.hpp
+++ b/include/pisa/index_metadata.hpp
@@ -1,0 +1,106 @@
+#pragma once
+
+#include <filesystem>
+#include <functional>
+#include <map>
+#include <string>
+
+#include <mio/mmap.hpp>
+
+namespace pisa {
+
+struct Query;
+
+namespace config {
+
+    /// Available stermmer types.
+    enum class Stemmer { Porter2 };
+
+    /// Available scorers.
+    enum class Scorer { BM25, QueryLikelihood };
+
+} // namespace config
+
+/// Any posting data, such as documents, frequencies, scores, or block max scores,
+/// have a postings file that contains data for one posting list after another,
+/// and an offset file.
+struct PostingFilePaths {
+    std::filesystem::path postings;
+    std::filesystem::path offsets;
+};
+
+/// Index metadata stores required paths and properties of an index.
+struct IndexMetadata {
+    /// Path to the metadata file. I suggest YAML.
+    std::optional<std::filesystem::path> meta_file;
+
+    /// Path to a file containing document lengths.
+    std::filesystem::path document_lengths;
+
+    /// Stemmer with which the collection was parsed.
+    std::optional<config::Stemmer> stemmer;
+
+    /// Lexicon paths
+    std::optional<std::filesystem::path> term_lexicon;
+    std::optional<std::filesystem::path> document_lexicon;
+
+    /// Statistics
+    float avg_document_length;
+    std::size_t document_count;
+    std::size_t posting_count;
+    std::size_t term_count;
+
+    /// Write this metadata to a file.
+    void write(std::filesystem::path const& file) const;
+
+    /// Update the same file it was loaded from. Will throw if `meta_file` is not set.
+    void update() const;
+
+    /// Loads metadata from a YAML file.
+    [[nodiscard]] static auto from_file(std::filesystem::path const& file) -> IndexMetadata;
+
+    /// Returns query parser with appropriate stemming.
+    [[nodiscard]] auto query_parser(std::optional<std::filesystem::path> const& stop_words =
+                                        std::nullopt) const -> std::function<Query(std::string)>;
+};
+
+struct DaatIndexMetadata : public IndexMetadata {
+    /// Paths to documents.
+    PostingFilePaths documents;
+    /// Paths to frequencies.
+    PostingFilePaths frequencies;
+    /// Optional paths to scores.
+    std::map<config::Scorer, PostingFilePaths> quantized_scores;
+
+    /// Term max scores
+    std::map<config::Scorer, std::filesystem::path> max_scores;
+    std::map<config::Scorer, std::filesystem::path> quantized_max_scores;
+
+    /// Block max scores
+    std::map<config::Scorer, PostingFilePaths> block_max_scores;
+    std::map<config::Scorer, PostingFilePaths> quantized_block_max_scores;
+};
+
+struct SaatIndexMetadata : public IndexMetadata {
+    /// SAAT index has postings in one place. We could technically separate scores and documents
+    /// but seeing that scores are an intrinsic part of a posting list block, maybe it's better
+    /// to leave them there. It's not like we can use different ones with the same postings,
+    /// because it would change the order.
+    PostingFilePaths postings;
+};
+
+/// This is a helpful class that makes it easy to create memory mapped files for index.
+class MMapSource {
+   public:
+    MMapSource() = default;
+    MMapSource(MMapSource&&) = default;
+    MMapSource(MMapSource const&) = default;
+    MMapSource& operator=(MMapSource&&) = default;
+    MMapSource& operator=(MMapSource const&) = default;
+    ~MMapSource() = default;
+
+   private:
+    std::vector<std::shared_ptr<mio::mmap_source>> file_sources{};
+};
+
+} // namespace pisa


### PR DESCRIPTION
This one only add cmake clang-tidy support, but does not turn it on by default.