### PR TITLE
modernize-use-equals-default + modernize-use-using

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,5 +1,4 @@
 ---
-WarningsAsErrors: '*'
 HeaderFilterRegex: '.*include/pisa.*\.hpp'
 FormatStyle: none
 Checks: |
@@ -7,4 +6,8 @@ Checks: |
     hicpp-use-auto,
     hicpp-move-const-arg,
     modernize-loop-convert,
-    readability-braces-around-statements
+    readability-braces-around-statements,
+    modernize-use-equals-default,
+    modernize-use-using,
+    -modernize-use-trailing-return-type,
+    -fuchsia-overloaded-operator

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,4 +1,5 @@
 ---
+WarningsAsErrors: '*'
 HeaderFilterRegex: '.*include/pisa.*\.hpp'
 FormatStyle: none
 Checks: |

--- a/benchmarks/scan_perftest.cpp
+++ b/benchmarks/scan_perftest.cpp
@@ -14,7 +14,7 @@ using pisa::get_time_usecs;
 template <typename BaseSequence>
 void perftest(const char* index_filename)
 {
-    typedef pisa::sequence_collection<BaseSequence> collection_type;
+    using collection_type = pisa::sequence_collection<BaseSequence>;
     spdlog::info("Loading collection from {}", index_filename);
     collection_type coll;
     mio::mmap_source m(index_filename);

--- a/include/pisa/binary_freq_collection.hpp
+++ b/include/pisa/binary_freq_collection.hpp
@@ -42,7 +42,7 @@ class binary_freq_collection {
 
     class iterator: public std::iterator<std::forward_iterator_tag, sequence> {
       public:
-        iterator() {}
+        iterator() = default;
 
         sequence const& operator*() const { return m_cur_seq; }
 

--- a/include/pisa/block_freq_index.hpp
+++ b/include/pisa/block_freq_index.hpp
@@ -80,7 +80,7 @@ class block_freq_index {
 
     uint64_t num_docs() const { return m_num_docs; }
 
-    typedef typename block_posting_list<BlockCodec, Profile>::document_enumerator document_enumerator;
+    using document_enumerator = typename block_posting_list<BlockCodec, Profile>::document_enumerator;
 
     document_enumerator operator[](size_t i) const
     {

--- a/include/pisa/codec/all_ones_sequence.hpp
+++ b/include/pisa/codec/all_ones_sequence.hpp
@@ -23,7 +23,7 @@ struct all_ones_sequence {
 
     class enumerator {
       public:
-        typedef std::pair<uint64_t, uint64_t> value_type;  // (position, value)
+        using value_type = std::pair<uint64_t, uint64_t>;  // (position, value)
 
         enumerator(bit_vector const&, uint64_t, uint64_t universe, uint64_t n, global_parameters const&)
             : m_universe(universe), m_position(size())

--- a/include/pisa/codec/compact_elias_fano.hpp
+++ b/include/pisa/codec/compact_elias_fano.hpp
@@ -21,7 +21,7 @@ namespace pisa {
 
 struct compact_elias_fano {
     struct offsets {
-        offsets() {}
+        offsets() = default;
 
         offsets(uint64_t base_offset, uint64_t universe, uint64_t n, global_parameters const& params)
             : universe(universe),
@@ -143,7 +143,7 @@ struct compact_elias_fano {
       public:
         typedef std::pair<uint64_t, uint64_t> value_type;  // (position, value)
 
-        enumerator() {}
+        enumerator() = default;
 
         enumerator(
             bit_vector const& bv,

--- a/include/pisa/codec/compact_elias_fano.hpp
+++ b/include/pisa/codec/compact_elias_fano.hpp
@@ -141,7 +141,7 @@ struct compact_elias_fano {
 
     class enumerator {
       public:
-        typedef std::pair<uint64_t, uint64_t> value_type;  // (position, value)
+        using value_type = std::pair<uint64_t, uint64_t>;  // (position, value)
 
         enumerator() = default;
 

--- a/include/pisa/codec/compact_ranked_bitvector.hpp
+++ b/include/pisa/codec/compact_ranked_bitvector.hpp
@@ -117,7 +117,7 @@ struct compact_ranked_bitvector {
 
     class enumerator {
       public:
-        typedef std::pair<uint64_t, uint64_t> value_type;  // (position, value)
+        using value_type = std::pair<uint64_t, uint64_t>;  // (position, value)
 
         enumerator(
             bit_vector const& bv,

--- a/include/pisa/codec/strict_elias_fano.hpp
+++ b/include/pisa/codec/strict_elias_fano.hpp
@@ -24,7 +24,7 @@ struct strict_elias_fano {
         global_parameters const& params)
     {
         uint64_t new_universe = universe - n + 1;
-        typedef typename std::iterator_traits<Iterator>::value_type value_type;
+        using value_type = typename std::iterator_traits<Iterator>::value_type;
         auto new_begin = make_function_iterator(
             std::make_pair(value_type(0), begin),
             [](std::pair<value_type, Iterator>& state) {
@@ -39,7 +39,7 @@ struct strict_elias_fano {
       public:
         typedef std::pair<uint64_t, uint64_t> value_type;  // (position, value)
 
-        enumerator() {}
+        enumerator() = default;
 
         enumerator(
             bit_vector const& bv,

--- a/include/pisa/codec/strict_elias_fano.hpp
+++ b/include/pisa/codec/strict_elias_fano.hpp
@@ -37,7 +37,7 @@ struct strict_elias_fano {
 
     class enumerator {
       public:
-        typedef std::pair<uint64_t, uint64_t> value_type;  // (position, value)
+        using value_type = std::pair<uint64_t, uint64_t>;  // (position, value)
 
         enumerator() = default;
 

--- a/include/pisa/mappable/mappable_vector.hpp
+++ b/include/pisa/mappable/mappable_vector.hpp
@@ -19,14 +19,14 @@ namespace pisa { namespace mapper {
         class sizeof_visitor;
     }  // namespace detail
 
-    typedef boost::function<void()> deleter_t;
+    using deleter_t = boost::function<void ()>;
 
     template <typename T>  // T must be a POD
     class mappable_vector {
       public:
-        typedef T value_type;
-        typedef const T* iterator;
-        typedef const T* const_iterator;
+        using value_type = T;
+        using iterator = const T *;
+        using const_iterator = const T *;
 
         mappable_vector() : m_data(0), m_size(0), m_deleter() {}
         mappable_vector(const mappable_vector&) = delete;

--- a/include/pisa/mappable/mappable_vector.hpp
+++ b/include/pisa/mappable/mappable_vector.hpp
@@ -19,14 +19,14 @@ namespace pisa { namespace mapper {
         class sizeof_visitor;
     }  // namespace detail
 
-    using deleter_t = boost::function<void ()>;
+    using deleter_t = boost::function<void()>;
 
     template <typename T>  // T must be a POD
     class mappable_vector {
       public:
         using value_type = T;
-        using iterator = const T *;
-        using const_iterator = const T *;
+        using iterator = const T*;
+        using const_iterator = const T*;
 
         mappable_vector() : m_data(0), m_size(0), m_deleter() {}
         mappable_vector(const mappable_vector&) = delete;

--- a/include/pisa/mappable/mapper.hpp
+++ b/include/pisa/mappable/mapper.hpp
@@ -14,7 +14,7 @@ namespace pisa { namespace mapper {
     };
 
     struct size_node;
-    typedef std::shared_ptr<size_node> size_node_ptr;
+    using size_node_ptr = std::shared_ptr<size_node>;
 
     struct size_node {
         size_node() : size(0) {}

--- a/include/pisa/mixed_block.hpp
+++ b/include/pisa/mixed_block.hpp
@@ -10,7 +10,7 @@ namespace pisa {
 struct mixed_block {
     enum class block_type : uint8_t { pfor = 0, varint = 1, interpolative = 2 };
 
-    typedef uint8_t compr_param_type;
+    using compr_param_type = uint8_t;
     static compr_param_type compr_params(block_type t)
     {
         switch (t) {

--- a/include/pisa/optimal_partition.hpp
+++ b/include/pisa/optimal_partition.hpp
@@ -7,8 +7,8 @@
 
 namespace pisa {
 
-typedef uint32_t posting_t;
-typedef uint64_t cost_t;
+using posting_t = uint32_t;
+using cost_t = uint64_t;
 
 struct optimal_partition {
     std::vector<posting_t> partition;
@@ -50,7 +50,7 @@ struct optimal_partition {
         }
     };
 
-    optimal_partition() {}
+    optimal_partition() = default;
 
     template <typename ForwardIterator, typename CostFunction>
     optimal_partition(

--- a/include/pisa/score_opt_partition.hpp
+++ b/include/pisa/score_opt_partition.hpp
@@ -8,8 +8,8 @@
 
 namespace pisa {
 
-typedef uint32_t posting_t;
-typedef float wand_cost_t;
+using posting_t = uint32_t;
+using wand_cost_t = float;
 
 struct score_opt_partition {
     std::vector<uint32_t> partition;
@@ -102,7 +102,7 @@ struct score_opt_partition {
         float max() { return max_queue.front(); }
     };
 
-    score_opt_partition() {}
+    score_opt_partition() = default;
 
     template <typename ForwardIterator>
     score_opt_partition(

--- a/include/pisa/sequence/indexed_sequence.hpp
+++ b/include/pisa/sequence/indexed_sequence.hpp
@@ -80,7 +80,7 @@ struct indexed_sequence {
       public:
         typedef std::pair<uint64_t, uint64_t> value_type;  // (position, value)
 
-        enumerator() {}
+        enumerator() = default;
 
         enumerator(
             bit_vector const& bv,

--- a/include/pisa/sequence/indexed_sequence.hpp
+++ b/include/pisa/sequence/indexed_sequence.hpp
@@ -78,7 +78,7 @@ struct indexed_sequence {
 
     class enumerator {
       public:
-        typedef std::pair<uint64_t, uint64_t> value_type;  // (position, value)
+        using value_type = std::pair<uint64_t, uint64_t>;  // (position, value)
 
         enumerator() = default;
 

--- a/include/pisa/sequence/partitioned_sequence.hpp
+++ b/include/pisa/sequence/partitioned_sequence.hpp
@@ -114,7 +114,7 @@ struct partitioned_sequence {
 
     class enumerator {
       public:
-        typedef std::pair<uint64_t, uint64_t> value_type;  // (position, value)
+        using value_type = std::pair<uint64_t, uint64_t>;  // (position, value)
 
         enumerator() = default;
 

--- a/include/pisa/sequence/partitioned_sequence.hpp
+++ b/include/pisa/sequence/partitioned_sequence.hpp
@@ -15,8 +15,8 @@ namespace pisa {
 
 template <typename BaseSequence = indexed_sequence>
 struct partitioned_sequence {
-    typedef BaseSequence base_sequence_type;
-    typedef typename base_sequence_type::enumerator base_sequence_enumerator;
+    using base_sequence_type = BaseSequence;
+    using base_sequence_enumerator = typename base_sequence_type::enumerator;
 
     template <typename Iterator>
     static void write(
@@ -116,7 +116,7 @@ struct partitioned_sequence {
       public:
         typedef std::pair<uint64_t, uint64_t> value_type;  // (position, value)
 
-        enumerator() {}
+        enumerator() = default;
 
         enumerator(
             bit_vector const& bv,

--- a/include/pisa/sequence/positive_sequence.hpp
+++ b/include/pisa/sequence/positive_sequence.hpp
@@ -29,7 +29,7 @@ struct positive_sequence {
 
     class enumerator {
       public:
-        typedef std::pair<uint64_t, uint64_t> value_type;  // (position, value)
+        using value_type = std::pair<uint64_t, uint64_t>;  // (position, value)
 
         enumerator() = delete;
 

--- a/include/pisa/sequence/positive_sequence.hpp
+++ b/include/pisa/sequence/positive_sequence.hpp
@@ -8,8 +8,8 @@ namespace pisa {
 
 template <typename BaseSequence = strict_sequence>
 struct positive_sequence {
-    typedef BaseSequence base_sequence_type;
-    typedef typename base_sequence_type::enumerator base_sequence_enumerator;
+    using base_sequence_type = BaseSequence;
+    using base_sequence_enumerator = typename base_sequence_type::enumerator;
 
     template <typename Iterator>
     static void write(

--- a/include/pisa/sequence/strict_sequence.hpp
+++ b/include/pisa/sequence/strict_sequence.hpp
@@ -90,7 +90,7 @@ struct strict_sequence {
       public:
         typedef std::pair<uint64_t, uint64_t> value_type;  // (position, value)
 
-        enumerator() {}
+        enumerator() = default;
 
         enumerator(
             bit_vector const& bv,

--- a/include/pisa/sequence/strict_sequence.hpp
+++ b/include/pisa/sequence/strict_sequence.hpp
@@ -88,7 +88,7 @@ struct strict_sequence {
 
     class enumerator {
       public:
-        typedef std::pair<uint64_t, uint64_t> value_type;  // (position, value)
+        using value_type = std::pair<uint64_t, uint64_t>;  // (position, value)
 
         enumerator() = default;
 

--- a/include/pisa/sequence/uniform_partitioned_sequence.hpp
+++ b/include/pisa/sequence/uniform_partitioned_sequence.hpp
@@ -103,7 +103,7 @@ struct uniform_partitioned_sequence {
 
     class enumerator {
       public:
-        using value_type = std::pair<uint64_t, uint64_t> ;  // (position, value)
+        using value_type = std::pair<uint64_t, uint64_t>;  // (position, value)
 
         enumerator() = default;
 

--- a/include/pisa/sequence/uniform_partitioned_sequence.hpp
+++ b/include/pisa/sequence/uniform_partitioned_sequence.hpp
@@ -12,8 +12,8 @@ namespace pisa {
 
 template <typename BaseSequence = indexed_sequence>
 struct uniform_partitioned_sequence {
-    typedef BaseSequence base_sequence_type;
-    typedef typename base_sequence_type::enumerator base_sequence_enumerator;
+    using base_sequence_type = BaseSequence;
+    using base_sequence_enumerator = typename base_sequence_type::enumerator;
 
     template <typename Iterator>
     static void write(
@@ -103,9 +103,9 @@ struct uniform_partitioned_sequence {
 
     class enumerator {
       public:
-        typedef std::pair<uint64_t, uint64_t> value_type;  // (position, value)
+        using value_type = std::pair<uint64_t, uint64_t> ;  // (position, value)
 
-        enumerator() {}
+        enumerator() = default;
 
         enumerator(
             bit_vector const& bv,

--- a/include/pisa/sequence_collection.hpp
+++ b/include/pisa/sequence_collection.hpp
@@ -11,9 +11,9 @@ namespace pisa {
 template <typename IndexedSequence>
 class sequence_collection {
   public:
-    typedef typename IndexedSequence::enumerator enumerator_type;
+    using enumerator_type = typename IndexedSequence::enumerator;
 
-    sequence_collection() {}
+    sequence_collection() = default;
 
     class builder {
       public:

--- a/include/pisa/util/block_profiler.hpp
+++ b/include/pisa/util/block_profiler.hpp
@@ -17,7 +17,7 @@ class block_profiler {
         }
     }
 
-    typedef std::atomic_uint_fast32_t counter_type;
+    using counter_type = std::atomic_uint_fast32_t;
 
     static block_profiler& get()
     {
@@ -55,7 +55,7 @@ class block_profiler {
     }
 
   private:
-    block_profiler() {}
+    block_profiler() = default;
 
     // XXX can't do vector of atomics ARGHH
     std::map<uint32_t, std::pair<size_t, counter_type*>> m_block_freqs;

--- a/include/pisa/util/semiasync_queue.hpp
+++ b/include/pisa/util/semiasync_queue.hpp
@@ -82,7 +82,7 @@ class semiasync_queue {
         m_running_threads.pop_front();
     }
 
-    typedef std::pair<std::vector<job_ptr_type>, std::thread> thread_t;
+    using thread_t = std::pair<std::vector<job_ptr_type>, std::thread>;
     thread_t m_next_thread;
     std::deque<thread_t> m_running_threads;
 

--- a/include/pisa/util/semiasync_queue.hpp
+++ b/include/pisa/util/semiasync_queue.hpp
@@ -24,7 +24,7 @@ class semiasync_queue {
         virtual ~job() = default;
     };
 
-    typedef std::shared_ptr<job> job_ptr_type;
+    using job_ptr_type = std::shared_ptr<job>;
 
     void add_job(job_ptr_type j, double expected_work)
     {

--- a/include/pisa/util/util.hpp
+++ b/include/pisa/util/util.hpp
@@ -65,7 +65,7 @@ template <typename State, typename AdvanceFunctor, typename ValueFunctor>
 class function_iterator
     : public std::iterator<std::forward_iterator_tag, typename std::result_of<ValueFunctor(State)>::type> {
   public:
-    function_iterator() {}
+    function_iterator() = default;
 
     function_iterator(State initial_state) : m_state(initial_state) {}
 
@@ -76,7 +76,7 @@ class function_iterator
     }
 
     // XXX why isn't this inherited from std::iterator?
-    typedef typename std::result_of<ValueFunctor(State)>::type value_type;
+    using value_type = typename std::result_of<ValueFunctor(State)>::type;
 
     value_type operator*() const
     {

--- a/include/pisa/wand_data.hpp
+++ b/include/pisa/wand_data.hpp
@@ -24,7 +24,7 @@ class wand_data {
   public:
     using wand_data_enumerator = typename block_wand_type::enumerator;
 
-    wand_data() {}
+    wand_data() = default;
 
     template <typename LengthsIterator>
     wand_data(

--- a/include/pisa/wand_data_raw.hpp
+++ b/include/pisa/wand_data_raw.hpp
@@ -15,7 +15,7 @@ namespace pisa {
 
 class wand_data_raw {
   public:
-    wand_data_raw() {}
+    wand_data_raw() = default;
 
     class builder {
       public:

--- a/test/test_block_freq_index.cpp
+++ b/test/test_block_freq_index.cpp
@@ -26,10 +26,10 @@ void test_block_freq_index()
 {
     pisa::global_parameters params;
     uint64_t universe = 20000;
-    typedef pisa::block_freq_index<BlockCodec> collection_type;
+    using collection_type = pisa::block_freq_index<BlockCodec>;
     typename collection_type::builder b(universe, params);
 
-    typedef std::vector<uint64_t> vec_type;
+    using vec_type = std::vector<uint64_t>;
     std::vector<std::pair<vec_type, vec_type>> posting_lists(30);
     for (auto& plist: posting_lists) {
         double avg_gap = 1.1 + double(rand()) / RAND_MAX * 10;

--- a/test/test_block_posting_list.cpp
+++ b/test/test_block_posting_list.cpp
@@ -59,7 +59,7 @@ void random_posting_data(
 template <typename BlockCodec>
 void test_block_posting_list()
 {
-    typedef pisa::block_posting_list<BlockCodec> posting_list_type;
+    using posting_list_type = pisa::block_posting_list<BlockCodec>;
     uint64_t universe = 20000;
     for (size_t t = 0; t < 20; ++t) {
         double avg_gap = 1.1 + double(rand()) / RAND_MAX * 10;
@@ -77,7 +77,7 @@ void test_block_posting_list()
 template <typename BlockCodec>
 void test_block_posting_list_reordering()
 {
-    typedef pisa::block_posting_list<BlockCodec> posting_list_type;
+    using posting_list_type = pisa::block_posting_list<BlockCodec>;
     uint64_t universe = 20000;
     for (size_t t = 0; t < 20; ++t) {
         double avg_gap = 1.1 + double(rand()) / RAND_MAX * 10;

--- a/test/test_freq_index.cpp
+++ b/test/test_freq_index.cpp
@@ -27,7 +27,7 @@ void test_freq_index()
     typedef pisa::freq_index<DocsSequence, FreqsSequence> collection_type;
     typename collection_type::builder b(universe, params);
 
-    typedef std::vector<uint64_t> vec_type;
+    using vec_type = std::vector<uint64_t>;
     std::vector<std::pair<vec_type, vec_type>> posting_lists(30);
     for (auto& plist: posting_lists) {
         double avg_gap = 1.1 + double(rand()) / RAND_MAX * 10;

--- a/test/test_freq_index.cpp
+++ b/test/test_freq_index.cpp
@@ -24,7 +24,7 @@ void test_freq_index()
     tbb::task_scheduler_init init;
     pisa::global_parameters params;
     uint64_t universe = 20000;
-    typedef pisa::freq_index<DocsSequence, FreqsSequence> collection_type;
+    using collection_type = pisa::freq_index<DocsSequence, FreqsSequence>;
     typename collection_type::builder b(universe, params);
 
     using vec_type = std::vector<uint64_t>;

--- a/test/test_partitioned_sequence.cpp
+++ b/test/test_partitioned_sequence.cpp
@@ -47,7 +47,7 @@ template <typename BaseSequence>
 void test_partitioned_sequence(uint64_t universe, std::vector<uint64_t> const& seq)
 {
     pisa::global_parameters params;
-    typedef pisa::partitioned_sequence<BaseSequence> sequence_type;
+    using sequence_type = pisa::partitioned_sequence<BaseSequence>;
 
     pisa::bit_vector_builder bvb;
     sequence_type::write(bvb, seq.begin(), universe, seq.size(), params);

--- a/test/test_positive_sequence.cpp
+++ b/test/test_positive_sequence.cpp
@@ -24,7 +24,7 @@ void test_positive_sequence()
     std::generate(values.begin(), values.end(), []() { return (rand() % 256) + 1; });
     uint64_t universe = std::accumulate(values.begin(), values.end(), 0) + 1;
 
-    typedef pisa::positive_sequence<BaseSequence> sequence_type;
+    using sequence_type = pisa::positive_sequence<BaseSequence>;
     pisa::bit_vector_builder bvb;
     sequence_type::write(bvb, values.begin(), universe, values.size(), params);
     pisa::bit_vector bv(&bvb);

--- a/test/test_sequence_collection.cpp
+++ b/test/test_sequence_collection.cpp
@@ -19,7 +19,7 @@ void test_sequence_collection()
 {
     pisa::global_parameters params;
     uint64_t universe = 10000;
-    typedef pisa::sequence_collection<BaseSequence> collection_type;
+    using collection_type = pisa::sequence_collection<BaseSequence>;
     typename collection_type::builder b(params);
 
     std::vector<std::vector<uint64_t>> sequences(30);

--- a/tools/optimal_hybrid_index.cpp
+++ b/tools/optimal_hybrid_index.cpp
@@ -381,7 +381,7 @@ void optimal_hybrid_index(
 
     stats_line()("found_space", cur_space)("found_time", cur_time);
 
-    typedef std::tuple<uint32_t, uint32_t> type_param_pair;
+    using type_param_pair = std::tuple<uint32_t, uint32_t>;
     std::map<type_param_pair, size_t> type_counts;
     for (size_t i = 0; i < num_blocks; ++i) {
         type_counts[type_param_pair((uint8_t)block_types[i], block_params[i])] += 1;
@@ -412,7 +412,7 @@ void optimal_hybrid_index(
     for (size_t l = 0; l < input_coll.size(); ++l) {
         auto e = input_coll[l];
 
-        typedef list_transformer<InputCollectionType, builder_type> job_type;
+        using job_type = list_transformer<InputCollectionType, builder_type>;
         std::shared_ptr<job_type> job(new job_type(builder, e, block_types_it, block_params_it));
 
         progress.update(1);

--- a/tools/optimal_hybrid_index.cpp
+++ b/tools/optimal_hybrid_index.cpp
@@ -23,7 +23,7 @@
 #include "util/util.hpp"
 #include "util/verify_collection.hpp"
 
-typedef uint32_t block_id_type;  // XXX for memory reasons, but would need size_t for very large
+using block_id_type = uint32_t;  // XXX for memory reasons, but would need size_t for very large
                                  // indexes
 
 struct lambda_point {
@@ -53,7 +53,7 @@ struct lambda_point {
     };
 };
 
-typedef stxxl::vector<lambda_point> lambda_vector_type;
+using lambda_vector_type = stxxl::vector<lambda_point>;
 
 template <typename InputCollectionType>
 struct lambdas_computer: pisa::semiasync_queue::job {
@@ -188,7 +188,7 @@ void compute_lambdas(
 
         auto e = input_coll[l];
 
-        typedef lambdas_computer<InputCollectionType> job_type;
+        using job_type = lambdas_computer<InputCollectionType>;
         std::shared_ptr<job_type> job;
 
         if (l == block_counts_list) {
@@ -247,8 +247,8 @@ struct list_transformer: pisa::semiasync_queue::job {
     {
         using namespace pisa;
 
-        typedef typename InputCollectionType::document_enumerator::block_data input_block_type;
-        typedef mixed_block::block_transformer<input_block_type> output_block_type;
+        using input_block_type = typename InputCollectionType::document_enumerator::block_data;
+        using output_block_type = mixed_block::block_transformer<input_block_type>;
 
         auto blocks = m_e.get_blocks();
         std::vector<output_block_type> output_blocks;
@@ -401,7 +401,7 @@ void optimal_hybrid_index(
 
     tick = get_time_usecs();
 
-    typedef typename block_mixed_index::builder builder_type;
+    using builder_type = typename block_mixed_index::builder;
     builder_type builder(input_coll.num_docs(), params);
     pisa::progress progress("Building collection", input_coll.size());
 

--- a/tools/profile_queries.cpp
+++ b/tools/profile_queries.cpp
@@ -56,7 +56,7 @@ struct add_profiling {
 
 template <typename BlockType>
 struct add_profiling<block_freq_index<BlockType, false>> {
-    typedef block_freq_index<BlockType, true> type;
+    using type = block_freq_index<BlockType, true>;
 };
 
 template <typename IndexType>

--- a/tools/profile_queries.cpp
+++ b/tools/profile_queries.cpp
@@ -51,7 +51,7 @@ void op_profile(QueryOperator const& query_op, std::vector<Query> const& queries
 
 template <typename IndexType>
 struct add_profiling {
-    typedef IndexType type;
+    using type = IndexType;
 };
 
 template <typename BlockType>
@@ -71,7 +71,7 @@ void profile(
     using namespace pisa;
 
     typename add_profiling<IndexType>::type index;
-    typedef wand_data<wand_data_raw> WandType;
+    using WandType = wand_data<wand_data_raw>;
     spdlog::info("Loading index from {}", index_filename);
     mio::mmap_source m(index_filename);
     mapper::map(index, m);


### PR DESCRIPTION
Fixes `modernize-use-equals-default` + `modernize-use-using` warnings.