### PR TITLE
Fix deprecated TBB calls

### DIFF
--- a/include/pisa/reorder_docids.hpp
+++ b/include/pisa/reorder_docids.hpp
@@ -9,8 +9,6 @@
 
 #include <gsl/span>
 #include <spdlog/spdlog.h>
-#include <tbb/task_group.h>
-#include <tbb/task_scheduler_init.h>
 
 #include "binary_freq_collection.hpp"
 #include "recursive_graph_bisection.hpp"

--- a/tools/evaluate_queries.cpp
+++ b/tools/evaluate_queries.cpp
@@ -199,8 +199,8 @@ int main(int argc, const char** argv)
 
     CLI11_PARSE(app, argc, argv);
 
-    tbb::global_control control(tbb::global_control::max_allowed_parallelism, app.threads());
-    spdlog::info("Number of threads: {}", app.threads());
+    tbb::global_control control(tbb::global_control::max_allowed_parallelism, app.threads() + 1);
+    spdlog::info("Number of worker threads: {}", app.threads());
 
     if (run_id.empty()) {
         run_id = "PISA";

--- a/tools/evaluate_queries.cpp
+++ b/tools/evaluate_queries.cpp
@@ -12,7 +12,7 @@
 #include <spdlog/sinks/stdout_color_sinks.h>
 #include <spdlog/spdlog.h>
 #include <tbb/parallel_for.h>
-#include <tbb/task_scheduler_init.h>
+#include <tbb/global_control.h>
 
 #include "accumulator/lazy_accumulator.hpp"
 #include "app.hpp"
@@ -199,7 +199,7 @@ int main(int argc, const char** argv)
 
     CLI11_PARSE(app, argc, argv);
 
-    tbb::task_scheduler_init init(app.threads());
+    tbb::global_control control(tbb::global_control::max_allowed_parallelism, app.threads());
     spdlog::info("Number of threads: {}", app.threads());
 
     if (run_id.empty()) {

--- a/tools/evaluate_queries.cpp
+++ b/tools/evaluate_queries.cpp
@@ -11,8 +11,8 @@
 #include <range/v3/view/enumerate.hpp>
 #include <spdlog/sinks/stdout_color_sinks.h>
 #include <spdlog/spdlog.h>
-#include <tbb/parallel_for.h>
 #include <tbb/global_control.h>
+#include <tbb/parallel_for.h>
 
 #include "accumulator/lazy_accumulator.hpp"
 #include "app.hpp"

--- a/tools/invert.cpp
+++ b/tools/invert.cpp
@@ -8,7 +8,7 @@
 #include "pstl/execution"
 #include "spdlog/spdlog.h"
 #include "tbb/task_group.h"
-#include "tbb/task_scheduler_init.h"
+#include "tbb/global_control.h"
 
 #include "app.hpp"
 #include "binary_collection.hpp"
@@ -20,7 +20,7 @@ int main(int argc, char** argv)
     CLI::App app{"Constructs an inverted index from a forward index."};
     pisa::InvertArgs args(&app);
     CLI11_PARSE(app, argc, argv);
-    tbb::task_scheduler_init init(args.threads());
+    tbb::global_control control(tbb::global_control::max_allowed_parallelism, args.threads());
     spdlog::info("Number of threads: {}", args.threads());
     pisa::invert::invert_forward_index(
         args.input_basename(),

--- a/tools/invert.cpp
+++ b/tools/invert.cpp
@@ -7,8 +7,8 @@
 #include "pstl/algorithm"
 #include "pstl/execution"
 #include "spdlog/spdlog.h"
-#include "tbb/task_group.h"
 #include "tbb/global_control.h"
+#include "tbb/task_group.h"
 
 #include "app.hpp"
 #include "binary_collection.hpp"

--- a/tools/invert.cpp
+++ b/tools/invert.cpp
@@ -20,8 +20,8 @@ int main(int argc, char** argv)
     CLI::App app{"Constructs an inverted index from a forward index."};
     pisa::InvertArgs args(&app);
     CLI11_PARSE(app, argc, argv);
-    tbb::global_control control(tbb::global_control::max_allowed_parallelism, args.threads());
-    spdlog::info("Number of threads: {}", args.threads());
+    tbb::global_control control(tbb::global_control::max_allowed_parallelism, args.threads() + 1);
+    spdlog::info("Number of worker threads: {}", args.threads());
     pisa::invert::invert_forward_index(
         args.input_basename(),
         args.output_basename(),

--- a/tools/parse_collection.cpp
+++ b/tools/parse_collection.cpp
@@ -62,8 +62,8 @@ int main(int argc, char** argv)
         spdlog::set_level(spdlog::level::debug);
     }
 
-    tbb::global_control control(tbb::global_control::max_allowed_parallelism, threads);
-    spdlog::info("Number of threads: {}", threads);
+    tbb::global_control control(tbb::global_control::max_allowed_parallelism, threads + 1);
+    spdlog::info("Number of worker threads: {}", threads);
 
     Forward_Index_Builder builder;
     if (*merge_cmd) {

--- a/tools/parse_collection.cpp
+++ b/tools/parse_collection.cpp
@@ -3,7 +3,7 @@
 #include <CLI/CLI.hpp>
 #include <fmt/format.h>
 #include <spdlog/spdlog.h>
-#include <tbb/task_scheduler_init.h>
+#include <tbb/global_control.h>
 
 #include "forward_index_builder.hpp"
 #include "parser.hpp"
@@ -62,7 +62,7 @@ int main(int argc, char** argv)
         spdlog::set_level(spdlog::level::debug);
     }
 
-    tbb::task_scheduler_init init(threads);
+    tbb::global_control control(tbb::global_control::max_allowed_parallelism, threads);
     spdlog::info("Number of threads: {}", threads);
 
     Forward_Index_Builder builder;

--- a/tools/partition_fwd_index.cpp
+++ b/tools/partition_fwd_index.cpp
@@ -53,8 +53,8 @@ int main(int argc, char** argv)
         spdlog::set_level(spdlog::level::debug);
     }
 
-    tbb::global_control control(tbb::global_control::max_allowed_parallelism, threads);
-    spdlog::info("Number of threads: {}", threads);
+    tbb::global_control control(tbb::global_control::max_allowed_parallelism, threads + 1);
+    spdlog::info("Number of worker threads: {}", threads);
 
     if (*random_option) {
         auto mapping = create_random_mapping(input_basename, shard_count);

--- a/tools/partition_fwd_index.cpp
+++ b/tools/partition_fwd_index.cpp
@@ -14,7 +14,7 @@
 #include <range/v3/view/enumerate.hpp>
 #include <range/v3/view/zip.hpp>
 #include <spdlog/spdlog.h>
-#include <tbb/task_scheduler_init.h>
+#include <tbb/global_control.h>
 
 #include "binary_collection.hpp"
 #include "io.hpp"
@@ -53,7 +53,7 @@ int main(int argc, char** argv)
         spdlog::set_level(spdlog::level::debug);
     }
 
-    tbb::task_scheduler_init init(threads);
+    tbb::global_control control(tbb::global_control::max_allowed_parallelism, threads);
     spdlog::info("Number of threads: {}", threads);
 
     if (*random_option) {

--- a/tools/shards.cpp
+++ b/tools/shards.cpp
@@ -5,8 +5,8 @@
 #include <CLI/CLI.hpp>
 #include <gsl/span>
 #include <spdlog/spdlog.h>
-#include <tbb/task_group.h>
 #include <tbb/global_control.h>
+#include <tbb/task_group.h>
 
 #include "app.hpp"
 #include "binary_collection.hpp"
@@ -45,7 +45,8 @@ int main(int argc, char** argv)
     CLI11_PARSE(app, argc, argv);
 
     if (invert->parsed()) {
-        tbb::global_control control(tbb::global_control::max_allowed_parallelism, invert_args.threads() + 1);
+        tbb::global_control control(
+            tbb::global_control::max_allowed_parallelism, invert_args.threads() + 1);
         spdlog::info("Number of worker threads: {}", invert_args.threads());
         Shard_Id shard_id{0};
         for (auto shard: resolve_shards(invert_args.input_basename())) {

--- a/tools/shards.cpp
+++ b/tools/shards.cpp
@@ -45,8 +45,8 @@ int main(int argc, char** argv)
     CLI11_PARSE(app, argc, argv);
 
     if (invert->parsed()) {
-        tbb::global_control control(tbb::global_control::max_allowed_parallelism, invert_args.threads());
-        spdlog::info("Number of threads: {}", invert_args.threads());
+        tbb::global_control control(tbb::global_control::max_allowed_parallelism, invert_args.threads() + 1);
+        spdlog::info("Number of worker threads: {}", invert_args.threads());
         Shard_Id shard_id{0};
         for (auto shard: resolve_shards(invert_args.input_basename())) {
             invert::invert_forward_index(

--- a/tools/shards.cpp
+++ b/tools/shards.cpp
@@ -6,7 +6,7 @@
 #include <gsl/span>
 #include <spdlog/spdlog.h>
 #include <tbb/task_group.h>
-#include <tbb/task_scheduler_init.h>
+#include <tbb/global_control.h>
 
 #include "app.hpp"
 #include "binary_collection.hpp"
@@ -45,7 +45,7 @@ int main(int argc, char** argv)
     CLI11_PARSE(app, argc, argv);
 
     if (invert->parsed()) {
-        tbb::task_scheduler_init init(invert_args.threads());
+        tbb::global_control control(tbb::global_control::max_allowed_parallelism, invert_args.threads());
         spdlog::info("Number of threads: {}", invert_args.threads());
         Shard_Id shard_id{0};
         for (auto shard: resolve_shards(invert_args.input_basename())) {


### PR DESCRIPTION
Fixes #368 by using the `tbb::global_control` class.

It seems that at alternative method would have been to use the `task_arena` but the current approach will work on a global basis (whereas task_arenas can limit threads on a per-arena basis) so this seemed like the best approach for now.
