### PR TITLE
Clean up wand requirements

### DIFF
--- a/tools/app.hpp
+++ b/tools/app.hpp
@@ -39,17 +39,15 @@ namespace arg {
     struct WandData {
         explicit WandData(CLI::App* app)
         {
+            auto* wand = app->add_option("-w,--wand", m_wand_data_path, "WAND data filename");
+            app->add_flag("--compressed-wand", m_wand_compressed, "Compressed WAND data file")
+                ->needs(wand);
+
             if constexpr (Mode == WandMode::Required) {
-                auto* wand =
-                    app->add_option("-w,--wand", m_wand_data_path, "WAND data filename")->required();
-                app->add_flag("--compressed-wand", m_wand_compressed, "Compressed WAND data file")
-                    ->needs(wand);
-            } else {
-                auto* wand = app->add_option("-w,--wand", m_wand_data_path, "WAND data filename");
-                app->add_flag("--compressed-wand", m_wand_compressed, "Compressed WAND data file")
-                    ->needs(wand);
+                wand->required();
             }
         }
+
         [[nodiscard]] auto wand_data_path() const
         {
             if constexpr (Mode == WandMode::Required) {

--- a/tools/app.hpp
+++ b/tools/app.hpp
@@ -40,21 +40,22 @@ namespace arg {
         explicit WandData(CLI::App* app)
         {
             if constexpr (Mode == WandMode::Required) {
-                auto* wand = app->add_option("-w,--wand", m_wand_data_path, "WAND data filename")->required();
+                auto* wand =
+                    app->add_option("-w,--wand", m_wand_data_path, "WAND data filename")->required();
                 app->add_flag("--compressed-wand", m_wand_compressed, "Compressed WAND data file")
-                ->needs(wand);
+                    ->needs(wand);
             } else {
                 auto* wand = app->add_option("-w,--wand", m_wand_data_path, "WAND data filename");
                 app->add_flag("--compressed-wand", m_wand_compressed, "Compressed WAND data file")
-                ->needs(wand);
+                    ->needs(wand);
             }
         }
         [[nodiscard]] auto wand_data_path() const
         {
-            if constexpr(Mode == WandMode::Required) {
-              return *m_wand_data_path;
+            if constexpr (Mode == WandMode::Required) {
+                return *m_wand_data_path;
             } else {
-              return m_wand_data_path;
+                return m_wand_data_path;
             }
         }
         [[nodiscard]] auto is_wand_compressed() const -> bool { return m_wand_compressed; }

--- a/tools/app.hpp
+++ b/tools/app.hpp
@@ -33,16 +33,29 @@ namespace arg {
         std::string m_encoding;
     };
 
+    enum class WandMode : bool { Required, Optional };
+
+    template <WandMode Mode = WandMode::Required>
     struct WandData {
         explicit WandData(CLI::App* app)
         {
-            auto* wand = app->add_option("-w,--wand", m_wand_data_path, "WAND data filename");
-            app->add_flag("--compressed-wand", m_wand_compressed, "Compressed WAND data file")
+            if constexpr (Mode == WandMode::Required) {
+                auto* wand = app->add_option("-w,--wand", m_wand_data_path, "WAND data filename")->required();
+                app->add_flag("--compressed-wand", m_wand_compressed, "Compressed WAND data file")
                 ->needs(wand);
+            } else {
+                auto* wand = app->add_option("-w,--wand", m_wand_data_path, "WAND data filename");
+                app->add_flag("--compressed-wand", m_wand_compressed, "Compressed WAND data file")
+                ->needs(wand);
+            }
         }
-        [[nodiscard]] auto wand_data_path() const -> std::optional<std::string> const&
+        [[nodiscard]] auto wand_data_path() const
         {
-            return m_wand_data_path;
+            if constexpr(Mode == WandMode::Required) {
+              return *m_wand_data_path;
+            } else {
+              return m_wand_data_path;
+            }
         }
         [[nodiscard]] auto is_wand_compressed() const -> bool { return m_wand_compressed; }
 

--- a/tools/compute_intersection.cpp
+++ b/tools/compute_intersection.cpp
@@ -86,7 +86,7 @@ int main(int argc, const char** argv)
     bool combinations = false;
     bool header = false;
 
-    App<arg::Index, arg::WandData, arg::Query<arg::QueryMode::Unranked>> app{
+    App<arg::Index, arg::WandData<arg::WandMode::Required>, arg::Query<arg::QueryMode::Unranked>> app{
         "Computes intersections of posting lists."};
     auto* combinations_flag = app.add_flag(
         "--combinations", combinations, "Compute intersections for combinations of terms in query");

--- a/tools/evaluate_queries.cpp
+++ b/tools/evaluate_queries.cpp
@@ -189,7 +189,13 @@ int main(int argc, const char** argv)
     std::string run_id = "R0";
     bool quantized = false;
 
-    App<arg::Index, arg::WandData<arg::WandMode::Required>, arg::Query<arg::QueryMode::Ranked>, arg::Algorithm, arg::Scorer, arg::Thresholds, arg::Threads>
+    App<arg::Index,
+        arg::WandData<arg::WandMode::Required>,
+        arg::Query<arg::QueryMode::Ranked>,
+        arg::Algorithm,
+        arg::Scorer,
+        arg::Thresholds,
+        arg::Threads>
         app{"Retrieves query results in TREC format."};
     app.add_option("-r,--run", run_id, "Run identifier");
     app.add_option("--documents", documents_file, "Document lexicon")->required();

--- a/tools/evaluate_queries.cpp
+++ b/tools/evaluate_queries.cpp
@@ -33,7 +33,7 @@ using ranges::views::enumerate;
 template <typename IndexType, typename WandType>
 void evaluate_queries(
     const std::string& index_filename,
-    const std::optional<std::string>& wand_data_filename,
+    const std::string& wand_data_filename,
     const std::vector<Query>& queries,
     const std::optional<std::string>& thresholds_filename,
     std::string const& type,
@@ -53,19 +53,17 @@ void evaluate_queries(
     auto scorer = scorer::from_params(scorer_params, wdata);
 
     mio::mmap_source md;
-    if (wand_data_filename) {
-        std::error_code error;
-        md.map(*wand_data_filename, error);
-        if (error) {
-            spdlog::error("error mapping file: {}, exiting...", error.message());
-            std::abort();
-        }
-        mapper::map(wdata, md, mapper::map_flags::warmup);
+    std::error_code error;
+    md.map(wand_data_filename, error);
+    if (error) {
+        spdlog::error("error mapping file: {}, exiting...", error.message());
+        std::abort();
     }
+    mapper::map(wdata, md, mapper::map_flags::warmup);
 
     std::function<std::vector<std::pair<float, uint64_t>>(Query)> query_fun;
 
-    if (query_type == "wand" && wand_data_filename) {
+    if (query_type == "wand") {
         query_fun = [&](Query query) {
             topk_queue topk(k);
             wand_query wand_q(topk);
@@ -73,7 +71,7 @@ void evaluate_queries(
             topk.finalize();
             return topk.topk();
         };
-    } else if (query_type == "block_max_wand" && wand_data_filename) {
+    } else if (query_type == "block_max_wand") {
         query_fun = [&](Query query) {
             topk_queue topk(k);
             block_max_wand_query block_max_wand_q(topk);
@@ -82,7 +80,7 @@ void evaluate_queries(
             topk.finalize();
             return topk.topk();
         };
-    } else if (query_type == "block_max_maxscore" && wand_data_filename) {
+    } else if (query_type == "block_max_maxscore") {
         query_fun = [&](Query query) {
             topk_queue topk(k);
             block_max_maxscore_query block_max_maxscore_q(topk);
@@ -91,7 +89,7 @@ void evaluate_queries(
             topk.finalize();
             return topk.topk();
         };
-    } else if (query_type == "block_max_ranked_and" && wand_data_filename) {
+    } else if (query_type == "block_max_ranked_and") {
         query_fun = [&](Query query) {
             topk_queue topk(k);
             block_max_ranked_and_query block_max_ranked_and_q(topk);
@@ -100,7 +98,7 @@ void evaluate_queries(
             topk.finalize();
             return topk.topk();
         };
-    } else if (query_type == "ranked_and" && wand_data_filename) {
+    } else if (query_type == "ranked_and") {
         query_fun = [&](Query query) {
             topk_queue topk(k);
             ranked_and_query ranked_and_q(topk);
@@ -108,7 +106,7 @@ void evaluate_queries(
             topk.finalize();
             return topk.topk();
         };
-    } else if (query_type == "ranked_or" && wand_data_filename) {
+    } else if (query_type == "ranked_or") {
         query_fun = [&](Query query) {
             topk_queue topk(k);
             ranked_or_query ranked_or_q(topk);
@@ -116,7 +114,7 @@ void evaluate_queries(
             topk.finalize();
             return topk.topk();
         };
-    } else if (query_type == "maxscore" && wand_data_filename) {
+    } else if (query_type == "maxscore") {
         query_fun = [&](Query query) {
             topk_queue topk(k);
             maxscore_query maxscore_q(topk);
@@ -124,7 +122,7 @@ void evaluate_queries(
             topk.finalize();
             return topk.topk();
         };
-    } else if (query_type == "ranked_or_taat" && wand_data_filename) {
+    } else if (query_type == "ranked_or_taat") {
         query_fun = [&, accumulator = Simple_Accumulator(index.num_docs())](Query query) mutable {
             topk_queue topk(k);
             ranked_or_taat_query ranked_or_taat_q(topk);
@@ -133,7 +131,7 @@ void evaluate_queries(
             topk.finalize();
             return topk.topk();
         };
-    } else if (query_type == "ranked_or_taat_lazy" && wand_data_filename) {
+    } else if (query_type == "ranked_or_taat_lazy") {
         query_fun = [&, accumulator = Lazy_Accumulator<4>(index.num_docs())](Query query) mutable {
             topk_queue topk(k);
             ranked_or_taat_query ranked_or_taat_q(topk);
@@ -191,7 +189,7 @@ int main(int argc, const char** argv)
     std::string run_id = "R0";
     bool quantized = false;
 
-    App<arg::Index, arg::WandData, arg::Query<arg::QueryMode::Ranked>, arg::Algorithm, arg::Scorer, arg::Thresholds, arg::Threads>
+    App<arg::Index, arg::WandData<arg::WandMode::Required>, arg::Query<arg::QueryMode::Ranked>, arg::Algorithm, arg::Scorer, arg::Thresholds, arg::Threads>
         app{"Retrieves query results in TREC format."};
     app.add_option("-r,--run", run_id, "Run identifier");
     app.add_option("--documents", documents_file, "Document lexicon")->required();

--- a/tools/queries.cpp
+++ b/tools/queries.cpp
@@ -306,7 +306,7 @@ int main(int argc, const char** argv)
     bool safe = false;
     bool quantized = false;
 
-    App<arg::Index, arg::WandData, arg::Query<arg::QueryMode::Ranked>, arg::Algorithm, arg::Scorer, arg::Thresholds>
+    App<arg::Index, arg::WandData<arg::WandMode::Optional>, arg::Query<arg::QueryMode::Ranked>, arg::Algorithm, arg::Scorer, arg::Thresholds>
         app{"Benchmarks queries on a given index."};
     app.add_flag("--quantized", quantized, "Quantized scores");
     app.add_flag("--extract", extract, "Extract individual query times");

--- a/tools/queries.cpp
+++ b/tools/queries.cpp
@@ -306,7 +306,12 @@ int main(int argc, const char** argv)
     bool safe = false;
     bool quantized = false;
 
-    App<arg::Index, arg::WandData<arg::WandMode::Optional>, arg::Query<arg::QueryMode::Ranked>, arg::Algorithm, arg::Scorer, arg::Thresholds>
+    App<arg::Index,
+        arg::WandData<arg::WandMode::Optional>,
+        arg::Query<arg::QueryMode::Ranked>,
+        arg::Algorithm,
+        arg::Scorer,
+        arg::Thresholds>
         app{"Benchmarks queries on a given index."};
     app.add_flag("--quantized", quantized, "Quantized scores");
     app.add_flag("--extract", extract, "Extract individual query times");

--- a/tools/thresholds.cpp
+++ b/tools/thresholds.cpp
@@ -48,7 +48,7 @@ void thresholds(
         std::abort();
     }
     mapper::map(wdata, md, mapper::map_flags::warmup);
-    
+
     topk_queue topk(k);
     wand_query wand_q(topk);
     for (auto const& query: queries) {
@@ -78,8 +78,8 @@ int main(int argc, const char** argv)
 
     bool quantized = false;
 
-    App<arg::Index, arg::WandData<arg::WandMode::Required>, arg::Query<arg::QueryMode::Ranked>, arg::Scorer> app{
-        "Extracts query thresholds."};
+    App<arg::Index, arg::WandData<arg::WandMode::Required>, arg::Query<arg::QueryMode::Ranked>, arg::Scorer>
+        app{"Extracts query thresholds."};
     app.add_flag("--quantized", quantized, "Quantizes the scores");
 
     CLI11_PARSE(app, argc, argv);

--- a/tools/thresholds.cpp
+++ b/tools/thresholds.cpp
@@ -25,7 +25,7 @@ using namespace pisa;
 template <typename IndexType, typename WandType>
 void thresholds(
     const std::string& index_filename,
-    const std::optional<std::string>& wand_data_filename,
+    const std::string& wand_data_filename,
     const std::vector<Query>& queries,
     std::string const& type,
     ScorerParams const& scorer_params,
@@ -41,15 +41,14 @@ void thresholds(
     auto scorer = scorer::from_params(scorer_params, wdata);
 
     mio::mmap_source md;
-    if (wand_data_filename) {
-        std::error_code error;
-        md.map(*wand_data_filename, error);
-        if (error) {
-            spdlog::error("error mapping file: {}, exiting...", error.message());
-            std::abort();
-        }
-        mapper::map(wdata, md, mapper::map_flags::warmup);
+    std::error_code error;
+    md.map(wand_data_filename, error);
+    if (error) {
+        spdlog::error("error mapping file: {}, exiting...", error.message());
+        std::abort();
     }
+    mapper::map(wdata, md, mapper::map_flags::warmup);
+    
     topk_queue topk(k);
     wand_query wand_q(topk);
     for (auto const& query: queries) {
@@ -79,7 +78,7 @@ int main(int argc, const char** argv)
 
     bool quantized = false;
 
-    App<arg::Index, arg::WandData, arg::Query<arg::QueryMode::Ranked>, arg::Scorer> app{
+    App<arg::Index, arg::WandData<arg::WandMode::Required>, arg::Query<arg::QueryMode::Ranked>, arg::Scorer> app{
         "Extracts query thresholds."};
     app.add_flag("--quantized", quantized, "Quantizes the scores");
 


### PR DESCRIPTION
Fixes #381 using the template approach as discussed. We can now specify wand data being required or optional on a per-binary basis.