### PR TITLE
Added kth_threshold tool

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -8,7 +8,7 @@ Welcome to PISA
 
 Performant Indexes and Search for Academia
 
-Description 
+Description
 ------------
 
 PISA is a text search engine able to run on large-scale collections of documents. It allows researchers to experiment with state-of-the-art techniques, allowing an ideal environment for rapid development.
@@ -25,14 +25,15 @@ Some features of PISA are listed below:
 .. note:: PISA is still in its **initial release** and many new features are going to come in the next versions. Contributions are also welcome!
 
 
-.. toctree::	
-   :maxdepth: 4	
-   :caption: Contents:	
+.. toctree::
+   :maxdepth: 4
+   :caption: Contents:
 
    getting_started
    parsing
    inverting
    sharding
-   compress_index	
-   query_index	
-   document_reordering	
+   compress_index
+   query_index
+   document_reordering
+   threshold_estimation

--- a/docs/source/threshold_estimation.md
+++ b/docs/source/threshold_estimation.md
@@ -1,0 +1,49 @@
+Threshold estimation
+=======
+
+Currently it is possible to perform threshold estimation tasks using the `kth_threshold` tool.
+The tool computes the k-highest impact score for each term of a query. Clearly, the top-k threshold of a query can be lower-bounded by the maximum of the k-th highest impact scores of the query terms.
+
+In addition to the k-th highest score for each individual term, it is possible to use the k-th highest score for certain pairs and triples of terms.
+
+To perform threshold estimation use the `kth_threshold` command:
+```bash
+A tool for performing threshold estimation using the k-highest impact score for each term, pair or triple of a query. Pairs and triples are only used if provided with --pairs and --triples respectively.
+Usage: ./bin/kth_threshold [OPTIONS]
+
+Options:
+  -h,--help                   Print this help message and exit
+  -e,--encoding TEXT REQUIRED Index encoding
+  -i,--index TEXT REQUIRED    Inverted index filename
+  -w,--wand TEXT REQUIRED     WAND data filename
+  --compressed-wand Needs: --wand
+                              Compressed WAND data file
+  -q,--queries TEXT           Path to file with queries
+  --terms TEXT                Term lexicon
+  --stopwords TEXT Needs: --terms
+                              List of blacklisted stop words to filter out
+  --stemmer TEXT Needs: --terms
+                              Stemmer type
+  -k INT REQUIRED             The number of top results to return
+  -s,--scorer TEXT REQUIRED   Scorer function
+  --bm25-k1 FLOAT Needs: --scorer
+                              BM25 k1 parameter.
+  --bm25-b FLOAT Needs: --scorer
+                              BM25 b parameter.
+  --pl2-c FLOAT Needs: --scorer
+                              PL2 c parameter.
+  --qld-mu FLOAT Needs: --scorer
+                              QLD mu parameter.
+  --config TEXT               Configuration .ini file
+  -p,--pairs TEXT Excludes: --all-pairs
+                              A tab separated file containing all the cached term pairs
+  -t,--triples TEXT Excludes: --all-triples
+                              A tab separated file containing all the cached term triples
+  --all-pairs Excludes: --pairs
+                              Consider all term pairs of a query
+  --all-triples Excludes: --triples
+                              Consider all term triples of a query
+  --quantized                 Quantizes the scores
+```
+
+`--all-pairs` and `--all-triples` can be used if you want to consider all the pairs and triples terms of a query as being previously cached.

--- a/include/pisa/topk_queue.hpp
+++ b/include/pisa/topk_queue.hpp
@@ -62,7 +62,7 @@ struct topk_queue {
 
     void set_threshold(Threshold t) noexcept { m_threshold = t; }
 
-    Threshold threshold() noexcept { return m_threshold; }
+    Threshold threshold() const noexcept { return m_threshold; }
 
     void clear() noexcept
     {

--- a/include/pisa/topk_queue.hpp
+++ b/include/pisa/topk_queue.hpp
@@ -70,7 +70,9 @@ struct topk_queue {
         m_threshold = 0;
     }
 
-    [[nodiscard]] uint64_t size() const noexcept { return m_k; }
+    [[nodiscard]] size_t capacity() const noexcept { return m_k; }
+
+    [[nodiscard]] size_t size() const noexcept { return m_q.size(); }
 
   private:
     float m_threshold;

--- a/include/pisa/topk_queue.hpp
+++ b/include/pisa/topk_queue.hpp
@@ -62,6 +62,8 @@ struct topk_queue {
 
     void set_threshold(Threshold t) noexcept { m_threshold = t; }
 
+    Threshold threshold() noexcept { return m_threshold; }
+
     void clear() noexcept
     {
         m_q.clear();

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -136,3 +136,9 @@ target_link_libraries(reorder-docids
   pisa
   CLI11
 )
+
+add_executable(kth_threshold kth_threshold.cpp)
+target_link_libraries(kth_threshold
+  pisa
+  CLI11
+)

--- a/tools/kth_threshold.cpp
+++ b/tools/kth_threshold.cpp
@@ -41,10 +41,7 @@ std::set<uint32_t> parse_tuple(std::string const& line, size_t k)
     for (auto&& term_id: term_ids) {
         try {
             term_ids_int.insert(std::stoi(term_id));
-        } catch (const std::invalid_argument& e) {
-            throw std::runtime_error(
-                fmt::format("Cannot convert {} to int in line: {}", term_id, line));
-        } catch (const std::out_of_range& e) {
+        } catch (...) {
             throw std::runtime_error(
                 fmt::format("Cannot convert {} to int in line: {}", term_id, line));
         }
@@ -123,7 +120,7 @@ void kt_thresholds(
             for (size_t j = i + 1; j < terms.size(); ++j) {
                 if (pairs_set.count({terms[i], terms[j]}) > 0) {
                     Query query;
-                    query.terms = {terms[i], terms[j]}
+                    query.terms = {terms[i], terms[j]};
                     wand_q(make_max_scored_cursors(index, wdata, *scorer, query), index.num_docs());
                     threshold = std::max(threshold, topk.size() == k ? topk.threshold() : 0.0F);
                 }
@@ -134,7 +131,7 @@ void kt_thresholds(
                 for (size_t s = j + 1; s < terms.size(); ++s) {
                     if (triples_set.count({terms[i], terms[j], terms[s]}) > 0) {
                         Query query;
-                        query.terms = {terms[i], terms[j], terms[s]}
+                        query.terms = {terms[i], terms[j], terms[s]};
                         wand_q(
                             make_max_scored_cursors(index, wdata, *scorer, query), index.num_docs());
                         threshold = std::max(threshold, topk.size() == k ? topk.threshold() : 0.0F);

--- a/tools/kth_threshold.cpp
+++ b/tools/kth_threshold.cpp
@@ -92,7 +92,7 @@ void kt_thresholds(
         topk_queue topk(k);
         wand_query wand_q(topk);
 
-        for(auto&& term : terms) {
+        for (auto&& term: terms) {
             Query q;
             q.terms.push_back(term);
             wand_q(make_max_scored_cursors(index, wdata, *scorer, q), index.num_docs());

--- a/tools/kth_threshold.cpp
+++ b/tools/kth_threshold.cpp
@@ -96,8 +96,6 @@ void kt_thresholds(
     if (triples_filename) {
         std::ifstream trin(*triples_filename);
         while (std::getline(trin, line)) {
-            std::vector<std::string> term_ids;
-            boost::algorithm::split(term_ids, line, boost::is_any_of(" \t"));
             triples_set.insert(parse_tuple(line, 3));
         }
         spdlog::info("Number of triples loaded: {}", triples_set.size());

--- a/tools/kth_threshold.cpp
+++ b/tools/kth_threshold.cpp
@@ -1,0 +1,211 @@
+#include <iostream>
+#include <optional>
+#include <unordered_set>
+
+#include "boost/algorithm/string/classification.hpp"
+#include "boost/algorithm/string/split.hpp"
+#include <boost/functional/hash.hpp>
+
+#include "mio/mmap.hpp"
+#include "spdlog/sinks/stdout_color_sinks.h"
+#include "spdlog/spdlog.h"
+
+#include "mappable/mapper.hpp"
+
+#include "app.hpp"
+#include "cursor/max_scored_cursor.hpp"
+#include "index_types.hpp"
+#include "io.hpp"
+#include "query/algorithm.hpp"
+#include "util/util.hpp"
+#include "wand_data_compressed.hpp"
+#include "wand_data_raw.hpp"
+
+#include "query/algorithm.hpp"
+#include "scorer/scorer.hpp"
+
+#include "CLI/CLI.hpp"
+
+using namespace pisa;
+
+template <typename IndexType, typename WandType>
+void kt_thresholds(
+    const std::string& index_filename,
+    const std::string& wand_data_filename,
+    const std::vector<Query>& queries,
+    std::string const& type,
+    ScorerParams const& scorer_params,
+    uint64_t k,
+    bool quantized,
+    std::optional<std::string> pairs_filename,
+    std::optional<std::string> triples_filename)
+{
+    IndexType index;
+    mio::mmap_source m(index_filename.c_str());
+    mapper::map(index, m);
+
+    WandType wdata;
+
+    auto scorer = scorer::from_params(scorer_params, wdata);
+
+    mio::mmap_source md;
+    std::error_code error;
+    md.map(wand_data_filename, error);
+    if (error) {
+        spdlog::error("error mapping file: {}, exiting...", error.message());
+        std::abort();
+    }
+    mapper::map(wdata, md, mapper::map_flags::warmup);
+
+    using Pair = std::set<uint32_t>;
+    std::unordered_set<Pair, boost::hash<Pair>> pairs_set;
+
+    using Triple = std::set<uint32_t>;
+    std::unordered_set<Triple, boost::hash<Triple>> triples_set;
+
+    std::string t;
+    if (pairs_filename) {
+        std::ifstream pin(*pairs_filename);
+        while (std::getline(pin, t)) {
+            std::vector<std::string> p;
+            boost::algorithm::split(p, t, boost::is_any_of(" \t"));
+            pairs_set.insert({(uint32_t)std::stoi(p[0]), (uint32_t)std::stoi(p[1])});
+        }
+        spdlog::info("Number of pairs loaded: {}", pairs_set.size());
+    }
+
+    if (triples_filename) {
+        std::ifstream trin(*triples_filename);
+        while (std::getline(trin, t)) {
+            std::vector<std::string> p;
+            boost::algorithm::split(p, t, boost::is_any_of(" \t"));
+            triples_set.insert(
+                {(uint32_t)std::stoi(p[0]), (uint32_t)std::stoi(p[1]), (uint32_t)std::stoi(p[2])});
+        }
+        spdlog::info("Number of triples loaded: {}", triples_set.size());
+    }
+
+    for (auto const& query: queries) {
+        float threshold = 0;
+
+        auto terms = query.terms;
+        topk_queue topk(k);
+        wand_query wand_q(topk);
+
+        for (size_t i = 0; i < terms.size(); ++i) {
+            Query q;
+            q.terms.push_back(terms[i]);
+            wand_q(make_max_scored_cursors(index, wdata, *scorer, q), index.num_docs());
+            topk.finalize();
+            auto results = topk.topk();
+            topk.clear();
+            float t = 0.0;
+            if (results.size() == k) {
+                t = results.back().first;
+            }
+            threshold = std::max(threshold, t);
+        }
+        for (size_t i = 0; i < terms.size(); ++i) {
+            for (size_t j = i + 1; j < terms.size(); ++j) {
+                if (pairs_set.count({terms[i], terms[j]})) {
+                    Query q;
+                    q.terms.push_back(terms[i]);
+                    q.terms.push_back(terms[j]);
+                    wand_q(make_max_scored_cursors(index, wdata, *scorer, q), index.num_docs());
+                    topk.finalize();
+                    auto results = topk.topk();
+                    topk.clear();
+                    float t = 0.0;
+                    if (results.size() == k) {
+                        t = results.back().first;
+                    }
+                    threshold = std::max(threshold, t);
+                }
+            }
+        }
+        for (size_t i = 0; i < terms.size(); ++i) {
+            for (size_t j = i + 1; j < terms.size(); ++j) {
+                for (size_t s = j + 1; s < terms.size(); ++s) {
+                    if (triples_set.count({terms[i], terms[j], terms[s]})) {
+                        Query q;
+                        q.terms.push_back(terms[i]);
+                        q.terms.push_back(terms[j]);
+                        q.terms.push_back(terms[s]);
+                        wand_q(make_max_scored_cursors(index, wdata, *scorer, q), index.num_docs());
+                        topk.finalize();
+                        auto results = topk.topk();
+                        topk.clear();
+                        float t = 0.0;
+                        if (results.size() == k) {
+                            t = results.back().first;
+                        }
+                        threshold = std::max(threshold, t);
+                    }
+                }
+            }
+        }
+        std::cout << threshold << '\n';
+    }
+}
+
+using wand_raw_index = wand_data<wand_data_raw>;
+using wand_uniform_index = wand_data<wand_data_compressed<>>;
+using wand_uniform_index_quantized = wand_data<wand_data_compressed<PayloadType::Quantized>>;
+
+int main(int argc, const char** argv)
+{
+    spdlog::drop("");
+    spdlog::set_default_logger(spdlog::stderr_color_mt(""));
+
+    std::string query_filename;
+    std::optional<std::string> pairs_filename;
+    std::optional<std::string> triples_filename;
+    size_t k;
+    std::string index_filename;
+    std::string wand_data_filename;
+    bool quantized = false;
+
+    App<arg::Index, arg::WandData<arg::WandMode::Required>, arg::Query<arg::QueryMode::Ranked>, arg::Scorer>
+        app{"A tool for performing threshold estimation using k-th score informations."};
+
+    app.add_option("-p,--pairs", pairs_filename, "Pairs filename");
+    app.add_option("-t,--triples", triples_filename, "Triples filename");
+    app.add_flag("--quantized", quantized, "Quantizes the scores");
+
+    CLI11_PARSE(app, argc, argv);
+
+    auto params = std::make_tuple(
+        app.index_filename(),
+        app.wand_data_path(),
+        app.queries(),
+        app.index_encoding(),
+        app.scorer_params(),
+        app.k(),
+        quantized,
+        pairs_filename,
+        triples_filename);
+
+    /**/
+    if (false) {
+#define LOOP_BODY(R, DATA, T)                                                                      \
+    }                                                                                              \
+    else if (app.index_encoding() == BOOST_PP_STRINGIZE(T))                                        \
+    {                                                                                              \
+        if (app.is_wand_compressed()) {                                                            \
+            if (quantized) {                                                                       \
+                std::apply(                                                                        \
+                    kt_thresholds<BOOST_PP_CAT(T, _index), wand_uniform_index_quantized>, params); \
+            } else {                                                                               \
+                std::apply(kt_thresholds<BOOST_PP_CAT(T, _index), wand_uniform_index>, params);    \
+            }                                                                                      \
+        } else {                                                                                   \
+            std::apply(kt_thresholds<BOOST_PP_CAT(T, _index), wand_raw_index>, params);            \
+        }
+        /**/
+        BOOST_PP_SEQ_FOR_EACH(LOOP_BODY, _, PISA_INDEX_TYPES);
+#undef LOOP_BODY
+
+    } else {
+        spdlog::error("Unknown type {}", app.index_encoding());
+    }
+}

--- a/tools/kth_threshold.cpp
+++ b/tools/kth_threshold.cpp
@@ -92,9 +92,9 @@ void kt_thresholds(
         topk_queue topk(k);
         wand_query wand_q(topk);
 
-        for (size_t i = 0; i < terms.size(); ++i) {
+        for(auto&& term : terms) {
             Query q;
-            q.terms.push_back(terms[i]);
+            q.terms.push_back(term);
             wand_q(make_max_scored_cursors(index, wdata, *scorer, q), index.num_docs());
             topk.finalize();
             auto results = topk.topk();

--- a/tools/kth_threshold.cpp
+++ b/tools/kth_threshold.cpp
@@ -165,7 +165,7 @@ int main(int argc, const char** argv)
 
     App<arg::Index, arg::WandData<arg::WandMode::Required>, arg::Query<arg::QueryMode::Ranked>, arg::Scorer>
         app{"A tool for performing threshold estimation using the k-highest impact score for each "
-            "term, pair or triple of a query."};
+            "term, pair or triple of a query. Pairs and triples are only used if provided with --pairs and --triples respectively."};
     auto pairs = app.add_option(
         "-p,--pairs", pairs_filename, "A tab separated file containing all the cached term pairs");
     auto triples = app.add_option(

--- a/tools/kth_threshold.cpp
+++ b/tools/kth_threshold.cpp
@@ -123,8 +123,7 @@ void kt_thresholds(
             for (size_t j = i + 1; j < terms.size(); ++j) {
                 if (pairs_set.count({terms[i], terms[j]}) > 0) {
                     Query query;
-                    query.terms.push_back(terms[i]);
-                    query.terms.push_back(terms[j]);
+                    query.terms = {terms[i], terms[j]}
                     wand_q(make_max_scored_cursors(index, wdata, *scorer, query), index.num_docs());
                     threshold = std::max(threshold, topk.size() == k ? topk.threshold() : 0.0F);
                 }
@@ -135,9 +134,7 @@ void kt_thresholds(
                 for (size_t s = j + 1; s < terms.size(); ++s) {
                     if (triples_set.count({terms[i], terms[j], terms[s]}) > 0) {
                         Query query;
-                        query.terms.push_back(terms[i]);
-                        query.terms.push_back(terms[j]);
-                        query.terms.push_back(terms[s]);
+                        query.terms = {terms[i], terms[j], terms[s]}
                         wand_q(
                             make_max_scored_cursors(index, wdata, *scorer, query), index.num_docs());
                         threshold = std::max(threshold, topk.size() == k ? topk.threshold() : 0.0F);

--- a/tools/kth_threshold.cpp
+++ b/tools/kth_threshold.cpp
@@ -165,7 +165,8 @@ int main(int argc, const char** argv)
 
     App<arg::Index, arg::WandData<arg::WandMode::Required>, arg::Query<arg::QueryMode::Ranked>, arg::Scorer>
         app{"A tool for performing threshold estimation using the k-highest impact score for each "
-            "term, pair or triple of a query. Pairs and triples are only used if provided with --pairs and --triples respectively."};
+            "term, pair or triple of a query. Pairs and triples are only used if provided with "
+            "--pairs and --triples respectively."};
     auto pairs = app.add_option(
         "-p,--pairs", pairs_filename, "A tab separated file containing all the cached term pairs");
     auto triples = app.add_option(

--- a/tools/kth_threshold.cpp
+++ b/tools/kth_threshold.cpp
@@ -109,7 +109,7 @@ void kt_thresholds(
             Query query;
             query.terms.push_back(term);
             wand_q(make_max_scored_cursors(index, wdata, *scorer, query), index.num_docs());
-            threshold = std::max(threshold, topk.size() == k ? topk.threshold() : 0.0f);
+            threshold = std::max(threshold, topk.size() == k ? topk.threshold() : 0.0F);
         }
         for (size_t i = 0; i < terms.size(); ++i) {
             for (size_t j = i + 1; j < terms.size(); ++j) {
@@ -118,7 +118,7 @@ void kt_thresholds(
                     query.terms.push_back(terms[i]);
                     query.terms.push_back(terms[j]);
                     wand_q(make_max_scored_cursors(index, wdata, *scorer, query), index.num_docs());
-                    threshold = std::max(threshold, topk.size() == k ? topk.threshold() : 0.0f);
+                    threshold = std::max(threshold, topk.size() == k ? topk.threshold() : 0.0F);
                 }
             }
         }
@@ -132,7 +132,7 @@ void kt_thresholds(
                         query.terms.push_back(terms[s]);
                         wand_q(
                             make_max_scored_cursors(index, wdata, *scorer, query), index.num_docs());
-                        threshold = std::max(threshold, topk.size() == k ? topk.threshold() : 0.0f);
+                        threshold = std::max(threshold, topk.size() == k ? topk.threshold() : 0.0F);
                     }
                 }
             }


### PR DESCRIPTION
A tool to predict the threshold of a query similarly to what is proposed in:
> Erman Yafay and Ismail Sengor Altingovde. 2019. Caching Scores for Faster Query Processing with Dynamic Pruning in Search Engines. In Proceedings of the 28th ACM International Conference on Information and Knowledge Management (CIKM ’19). Association for Computing Machinery, New York, NY, USA, 2457–2460. DOI:https://doi.org/10.1145/3357384.3358154
