### PR TITLE
Fix lexicon issue in term processor and refactor binary search

### DIFF
--- a/include/pisa/payload_vector.hpp
+++ b/include/pisa/payload_vector.hpp
@@ -51,8 +51,9 @@ namespace detail {
 
         [[nodiscard]] constexpr auto operator+(size_type n) const -> Payload_Vector_Iterator
         {
-            return {std::next(offset_iter, n),
-                    std::next(payload_iter, *std::next(offset_iter, n) - *offset_iter)};
+            return {
+                std::next(offset_iter, n),
+                std::next(payload_iter, *std::next(offset_iter, n) - *offset_iter)};
         }
 
         [[nodiscard]] constexpr auto operator+=(size_type n) -> Payload_Vector_Iterator&
@@ -64,8 +65,9 @@ namespace detail {
 
         [[nodiscard]] constexpr auto operator-(size_type n) const -> Payload_Vector_Iterator
         {
-            return {std::prev(offset_iter, n),
-                    std::prev(payload_iter, *offset_iter - *std::prev(offset_iter, n))};
+            return {
+                std::prev(offset_iter, n),
+                std::prev(payload_iter, *offset_iter - *std::prev(offset_iter, n))};
         }
 
         [[nodiscard]] constexpr auto operator-=(size_type n) -> Payload_Vector_Iterator&
@@ -333,6 +335,34 @@ class Payload_Vector {
     gsl::span<size_type const> offsets_;
     gsl::span<std::byte const> payloads_;
 };
+
+/// Find the position of `value` in a sorted range.
+///
+/// \tparam Iter   A random access iterator type.
+/// \tparam T      Element type, must be convertible to
+///                `std::iterator_traits<Iter>::difference_type`
+///
+/// The function assumes that the elements between `begin` and `end` are sorted according to `cmp`.
+template <typename Iter, typename T, typename Compare = std::less<>>
+auto binary_search(Iter begin, Iter end, T value, Compare cmp = std::less<>{})
+    -> std::optional<typename std::iterator_traits<Iter>::difference_type>
+{
+    if (auto pos = std::lower_bound(begin, end, value, cmp); pos != end and *pos == value) {
+        return std::distance(begin, pos);
+    }
+    return std::nullopt;
+}
+
+/// Find the position of `value` in a sorted range.
+///
+/// It calls the function overload that takes iterators. See that overload's documentation for more
+/// information.
+template <typename T, typename Compare = std::less<T>>
+auto binary_search(gsl::span<std::add_const_t<T>> range, T value, Compare cmp = std::less<T>{})
+    -> std::optional<std::ptrdiff_t>
+{
+    return pisa::binary_search(range.begin(), range.end(), value, cmp);
+}
 
 }  // namespace pisa
 

--- a/include/pisa/query/term_processor.hpp
+++ b/include/pisa/query/term_processor.hpp
@@ -65,11 +65,7 @@ class TermProcessor {
         auto terms = Payload_Vector<>::from(*source);
         auto to_id = [source = std::move(source), terms](auto str) -> std::optional<term_id_type> {
             // Note: the lexicographical order of the terms matters.
-            auto pos = std::lower_bound(terms.begin(), terms.end(), std::string_view(str));
-            if (*pos == std::string_view(str)) {
-                return std::distance(terms.begin(), pos);
-            }
-            return std::nullopt;
+            return pisa::binary_search(terms.begin(), terms.end(), std::string_view(str));
         };
 
         // Implements '_to_id' method.

--- a/tools/lexicon.cpp
+++ b/tools/lexicon.cpp
@@ -54,9 +54,9 @@ int main(int argc, char** argv)
             return 1;
         }
         if (*rlookup) {
-            auto pos = std::lower_bound(lexicon.begin(), lexicon.end(), std::string_view(value));
-            if (pos != lexicon.end() and *pos == std::string_view(value)) {
-                std::cout << std::distance(lexicon.begin(), pos) << '\n';
+            auto pos = pisa::binary_search(lexicon.begin(), lexicon.end(), std::string_view(value));
+            if (pos) {
+                std::cout << *pos << '\n';
                 return 0;
             }
             spdlog::error("Requested term {} was not found", value);


### PR DESCRIPTION
The issue was that the binary search didn't check if the iterator is `end()` which made things crash when a word was being looked up which is larger lexicographically than the last element in the lexicon.

The problem wasn't there in `lexicon` tool but was in the term processor. So I extracted the logic to a common function to avoid a situation like that in the future. Also added some tests.