### PR TITLE
Fix reading bytes from bit vector

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,7 @@ jobs:
           if [ "${cc}" = "clang-10" ]; then
             wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
             sudo add-apt-repository "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-10 main"
+            sudo apt-get remove libstdc++-10-dev libgcc-10-dev cpp-10
           fi
           if [ "${cc}" = "clang-6.0" ]; then
             # Problems compiling with Clang 6 against libstdc++-9

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,9 @@ jobs:
             sudo apt-get remove libstdc++-9-dev libgcc-9-dev cpp-9
           fi
           sudo apt-get update
+          sudo apt-get install launchpad-getkeys
+          sudo launchpad-getkeys
+          sudo apt-get update
           sudo apt-get install -y libtool m4 autoconf
           if [ "${{ matrix.compiler }}" = "gcc" ]; then
               sudo apt-get install -y "${cxx}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,7 @@ jobs:
           if [ "${cc}" = "clang-6.0" ]; then
             # Problems compiling with Clang 6 against libstdc++-9
             sudo apt-get remove libstdc++-9-dev libgcc-9-dev cpp-9
+            sudo apt-get remove libstdc++-10-dev libgcc-10-dev cpp-10
           fi
           sudo apt-get update
           sudo apt-get install -y libtool m4 autoconf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,14 +52,12 @@ jobs:
 
           if [ "${cc}" = "clang-10" ]; then
             sudo add-apt-repository "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-10 main"
+            wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
           fi
           if [ "${cc}" = "clang-6.0" ]; then
             # Problems compiling with Clang 6 against libstdc++-9
             sudo apt-get remove libstdc++-9-dev libgcc-9-dev cpp-9
           fi
-          sudo apt-get update
-          sudo apt-get install launchpad-getkeys
-          sudo launchpad-getkeys
           sudo apt-get update
           sudo apt-get install -y libtool m4 autoconf
           if [ "${{ matrix.compiler }}" = "gcc" ]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,8 +51,8 @@ jobs:
           cxx="${cxx/gcc/g++}"
 
           if [ "${cc}" = "clang-10" ]; then
-            sudo add-apt-repository "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-10 main"
             wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+            sudo add-apt-repository "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-10 main"
           fi
           if [ "${cc}" = "clang-6.0" ]; then
             # Problems compiling with Clang 6 against libstdc++-9

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -16,6 +16,9 @@ jobs:
     - name: Install clang-format
       shell: bash
       run: |
+          sudo apt-get update
+          sudo apt-get install launchpad-getkeys
+          sudo launchpad-getkeys
           sudo add-apt-repository "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-9 main"
           sudo apt-get update
           sudo apt-get install -y clang-format-9

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -16,14 +16,7 @@ jobs:
     - name: Install clang-format
       shell: bash
       run: |
-          sudo apt-get update
-          sudo apt-get install launchpad-getkeys
-          sudo launchpad-getkeys
-          sudo add-apt-repository "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-9 main"
-          sudo apt-get update
           sudo apt-get install -y clang-format-9
-          echo "::set-env name=CC::clang-9
-          echo "::set-env name=CXX::clang++-10
 
     - name: Set up Python
       uses: actions/setup-python@v1

--- a/.github/workflows/tidy.yml
+++ b/.github/workflows/tidy.yml
@@ -16,8 +16,8 @@ jobs:
     - name: Install clang and clang-tidy
       shell: bash
       run: |
-          sudo add-apt-repository "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-10 main"
           wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+          sudo add-apt-repository "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-10 main"
           sudo apt-get update
           sudo apt-get install -y clang-10 clang-tidy-10
           sudo apt-get install -y libtool m4 autoconf

--- a/.github/workflows/tidy.yml
+++ b/.github/workflows/tidy.yml
@@ -16,10 +16,8 @@ jobs:
     - name: Install clang and clang-tidy
       shell: bash
       run: |
-          sudo apt-get update
-          sudo apt-get install launchpad-getkeys
-          sudo launchpad-getkeys
           sudo add-apt-repository "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-10 main"
+          wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
           sudo apt-get update
           sudo apt-get install -y clang-10 clang-tidy-10
           sudo apt-get install -y libtool m4 autoconf

--- a/.github/workflows/tidy.yml
+++ b/.github/workflows/tidy.yml
@@ -21,6 +21,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y clang-10 clang-tidy-10
           sudo apt-get install -y libtool m4 autoconf
+          sudo apt-get remove libstdc++-10-dev libgcc-10-dev cpp-10
           echo "::set-env name=CC::clang-10"
           echo "::set-env name=CXX::clang++-10"
 

--- a/.github/workflows/tidy.yml
+++ b/.github/workflows/tidy.yml
@@ -16,6 +16,9 @@ jobs:
     - name: Install clang and clang-tidy
       shell: bash
       run: |
+          sudo apt-get update
+          sudo apt-get install launchpad-getkeys
+          sudo launchpad-getkeys
           sudo add-apt-repository "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-10 main"
           sudo apt-get update
           sudo apt-get install -y clang-10 clang-tidy-10

--- a/include/pisa/codec/block_codecs.hpp
+++ b/include/pisa/codec/block_codecs.hpp
@@ -156,7 +156,7 @@ struct interpolative_block {
         out[n - 1] = sum_of_values;
         size_t read_interpolative = 0;
         if (n > 1) {
-            bit_reader br((uint32_t const*)inbuf);
+            bit_reader br(inbuf);
             br.read_interpolative(out, n - 1, 0, sum_of_values);
             for (size_t i = n - 1; i > 0; --i) {
                 out[i] -= out[i - 1];

--- a/include/pisa/codec/interpolative_coding.hpp
+++ b/include/pisa/codec/interpolative_coding.hpp
@@ -73,7 +73,7 @@ class bit_writer {
 
 class bit_reader {
   public:
-    explicit bit_reader(uint32_t const* in) : m_in(in), m_avail(0), m_buf(0), m_pos(0) {}
+    explicit bit_reader(std::uint8_t const* in) : m_in(in), m_avail(0), m_buf(0), m_pos(0) {}
 
     size_t position() const { return m_pos; }
 
@@ -83,10 +83,11 @@ class bit_reader {
             return 0;
         }
 
-        if (m_avail < len) {
-            m_buf |= uint64_t(*m_in++) << m_avail;
-            m_avail += 32;
+        while (m_avail < len) {
+            m_buf |= static_cast<std::uint64_t>(*m_in++) << m_avail;
+            m_avail += 8;
         }
+
         uint32_t val = m_buf & ((uint64_t(1) << len) - 1);
         m_buf >>= len;
         m_avail -= len;
@@ -132,7 +133,7 @@ class bit_reader {
     }
 
   private:
-    uint32_t const* m_in;
+    std::uint8_t const* m_in;
     uint32_t m_avail;
     uint64_t m_buf;
     size_t m_pos;

--- a/include/pisa/forward_index_builder.hpp
+++ b/include/pisa/forward_index_builder.hpp
@@ -206,8 +206,8 @@ class Forward_Index_Builder {
             auto first = std::next(terms.begin(), lhs.first);
             auto mid = std::next(terms.begin(), lhs.last);
             auto last = std::next(terms.begin(), rhs.last);
-            std::inplace_merge(std::execution::par, first, mid, last);
-            terms.erase(std::unique(std::execution::par, first, last), last);
+            std::inplace_merge(pstl::execution::par, first, mid, last);
+            terms.erase(std::unique(pstl::execution::par, first, last), last);
             return Term_Span{lhs.first, terms.size(), lhs.lvl + 1};
         };
         auto push_span = [&](Term_Span s) {

--- a/include/pisa/invert.hpp
+++ b/include/pisa/invert.hpp
@@ -198,7 +198,7 @@ namespace invert {
     {
         std::vector<uint32_t> document_sizes(documents.size());
         std::transform(
-            std::execution::par_unseq,
+            pstl::execution::par_unseq,
             documents.begin(),
             documents.end(),
             document_sizes.begin(),
@@ -211,13 +211,13 @@ namespace invert {
             auto first_document_in_batch = first_document_id + first_idx_in_batch;
             auto last_document_in_batch = first_document_id + last_idx_in_batch;
             auto current_batch_size = last_idx_in_batch - first_idx_in_batch;
-            batches.push_back(
-                Batch{documents.subspan(first_idx_in_batch, current_batch_size),
-                      ranges::views::iota(first_document_in_batch, last_document_in_batch)});
+            batches.push_back(Batch{
+                documents.subspan(first_idx_in_batch, current_batch_size),
+                ranges::views::iota(first_document_in_batch, last_document_in_batch)});
         }
         std::vector<std::vector<std::pair<Term_Id, Document_Id>>> posting_vectors(batches.size());
         std::transform(
-            std::execution::par_unseq,
+            pstl::execution::par_unseq,
             batches.begin(),
             batches.end(),
             std::begin(posting_vectors),
@@ -226,7 +226,7 @@ namespace invert {
         posting_vectors.clear();
         posting_vectors.shrink_to_fit();
 
-        std::sort(std::execution::par_unseq, postings.begin(), postings.end());
+        std::sort(pstl::execution::par_unseq, postings.begin(), postings.end());
 
         using iterator_type = decltype(postings.begin());
         invert::Inverted_Index<iterator_type> index;

--- a/include/pisa/recursive_graph_bisection.hpp
+++ b/include/pisa/recursive_graph_bisection.hpp
@@ -82,9 +82,10 @@ class document_range {
     PISA_ALWAYSINLINE document_partition<Iterator> split() const
     {
         Iterator mid = std::next(m_first, size() / 2);
-        return {document_range(m_first, mid, m_fwdidx, m_gains),
-                document_range(mid, m_last, m_fwdidx, m_gains),
-                term_count()};
+        return {
+            document_range(m_first, mid, m_fwdidx, m_gains),
+            document_range(mid, m_last, m_fwdidx, m_gains),
+            term_count()};
     }
 
     PISA_ALWAYSINLINE document_range operator()(std::ptrdiff_t left, std::ptrdiff_t right) const
@@ -164,7 +165,7 @@ void compute_degrees(document_range<Iterator>& range, single_init_vector<size_t>
     for (const auto& document: range) {
         auto terms = range.terms(document);
         auto deg_map_inc = [&](const auto& t) { deg_map.set(t, deg_map[t] + 1); };
-        std::for_each(std::execution::unseq, terms.begin(), terms.end(), deg_map_inc);
+        std::for_each(pstl::execution::unseq, terms.begin(), terms.end(), deg_map_inc);
     }
 }
 
@@ -272,14 +273,14 @@ void process_partition(
         tbb::parallel_invoke(
             [&] {
                 std::sort(
-                    std::execution::par_unseq,
+                    pstl::execution::par_unseq,
                     partition.left.begin(),
                     partition.left.end(),
                     partition.left.by_gain());
             },
             [&] {
                 std::sort(
-                    std::execution::par_unseq,
+                    pstl::execution::par_unseq,
                     partition.right.begin(),
                     partition.right.end(),
                     partition.right.by_gain());

--- a/include/pisa/sharding.hpp
+++ b/include/pisa/sharding.hpp
@@ -278,7 +278,7 @@ auto partition_fwd_index(
     auto shard_ids = ranges::views::iota(0_s, shard_count) | ranges::to_vector;
     rearrange_sequences(input_basename, output_basename, mapping, shard_count);
     spdlog::info("Remapping shards");
-    std::for_each(std::execution::par_unseq, shard_ids.begin(), shard_ids.end(), [&](auto&& id) {
+    std::for_each(pstl::execution::par_unseq, shard_ids.begin(), shard_ids.end(), [&](auto&& id) {
         process_shard(input_basename, output_basename, id, terms);
     });
 }


### PR DESCRIPTION
This fix addresses two issues in the interpolative coding. First, we reinterpreted an arbitrary buffer of bytes as 32-bit ints, which introduced undefined behavior. We can do that safely with `std::memcpy`. However, there's another issue that actually is worse: if I understand this right, even though the bit writer uses 32-bit ints as a buffer, the block interpolative codec actually truncates the memory to the exact number of bytes. But in the reader, we still assumed we can just read another 4 bytes each time we run out of buffered bits, which is incorrect and causes reads after buffer.

This might not be a problem most of the time, because we usually just own that memory anyway. But not if that's the last posting list. Also, I was working on another memory source that reads from disk posting lists, and in that case this problem is very bad.

The solution from this PR has possible performance issues. But I don't imagine it's very important, since it's in the already slow interpolative encoding anyway, and in other block codecs we only use it to encode (possibly) the last block (which is the one that's the most problematic). The advantage of this fix is that it is actually correct.

That said, I'm investigating strange segfaults in my experiments, and this is just one of many issues I've noticed. So until I solve my problem, I might either fix or report a few more of these.