### PR TITLE
Modify count-postings tool

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -72,4 +72,6 @@ jobs:
     - name: Test CLI
       shell: bash
       working-directory: ${{runner.workspace}}/build
+      env:
+          TEST_DIR: ../pisa/test
       run: ../pisa/test/cli/run.sh

--- a/test/cli/run.sh
+++ b/test/cli/run.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
 
 DIR=$(dirname "$0")
+bats $DIR/setup.sh
 bats $DIR/test_taily_stats.sh
+bats $DIR/test_count_postings.sh

--- a/test/cli/setup.sh
+++ b/test/cli/setup.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+# This script should be executed within the build directory that is directly
+# in the project directory, e.g., /path/to/pisa/build
+
+PISA_BIN="./bin"
+export PATH="$PISA_BIN:$PATH"
+
+cat "../test/test_data/clueweb1k.plaintext" | parse_collection \
+    --stemmer porter2 \
+    --output "./fwd" \
+    --format plaintext
+
+invert --input "./fwd" --output "./inv"
+
+compress_inverted_index --check \
+    --encoding block_simdbp \
+    --collection "./inv" \
+    --output "./simdbp"
+
+create_wand_data \
+    --scorer bm25 \
+    --collection "./inv" \
+    --output "./bm25.bmw" \
+    --block-size 32
+
+partition_fwd_index \
+    --input "./fwd" \
+    --output "./fwd.shard" \
+    --shard-files ../test/test_data/clueweb1k.shard.*
+
+shards invert \
+    --input "./fwd.shard" \
+    --output "./inv.shard"

--- a/test/cli/setup.sh
+++ b/test/cli/setup.sh
@@ -6,7 +6,8 @@
 PISA_BIN="./bin"
 export PATH="$PISA_BIN:$PATH"
 
-cat "../test/test_data/clueweb1k.plaintext" | parse_collection \
+test_dir=${TEST_DIR:-../test}
+cat "$test_dir/test_data/clueweb1k.plaintext" | parse_collection \
     --stemmer porter2 \
     --output "./fwd" \
     --format plaintext
@@ -27,7 +28,7 @@ create_wand_data \
 partition_fwd_index \
     --input "./fwd" \
     --output "./fwd.shard" \
-    --shard-files ../test/test_data/clueweb1k.shard.*
+    --shard-files $TEST_DIR/test_data/clueweb1k.shard.*
 
 shards invert \
     --input "./fwd.shard" \

--- a/test/cli/test_count_postings.sh
+++ b/test/cli/test_count_postings.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bats
+
+set +x
+
+PISA_BIN="bin"
+export PATH="$PISA_BIN:$PATH"
+DIR=$(dirname "$0")
+
+@test "Extract posting counts" {
+    expected_1=$(read_collection -c inv.docs entry 1 | wc -w)
+    expected_2=$(read_collection -c inv.docs entry 2 | wc -w)
+    actual_1=$(echo 0 | count-postings -e block_simdbp -i simdbp)
+    actual_2=$(echo 1 | count-postings -e block_simdbp -i simdbp)
+    expected_sum=$((expected_1 + expected_2))
+    actual_sum=$(echo 0 1 | count-postings -e block_simdbp -i simdbp)
+    [[ "$expected_1" = "$actual_1" ]]
+    [[ "$expected_2" = "$actual_2" ]]
+    [[ "$expected_sum" = "$actual_sum" ]]
+}

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -98,8 +98,8 @@ target_link_libraries(stem_queries
   CLI11
 )
 
-add_executable(count_postings count_postings.cpp)
-target_link_libraries(count_postings
+add_executable(count-postings count_postings.cpp)
+target_link_libraries(count-postings
   pisa
   CLI11
 )

--- a/tools/count_postings.cpp
+++ b/tools/count_postings.cpp
@@ -1,34 +1,51 @@
 #include <iostream>
+#include <numeric>
+#include <vector>
 
 #include <CLI/CLI.hpp>
 #include <spdlog/sinks/stdout_color_sinks.h>
 #include <spdlog/spdlog.h>
 
+#include "app.hpp"
 #include "binary_collection.hpp"
+#include "index_types.hpp"
 
 using namespace pisa;
+
+template <typename Index>
+void extract(std::string const& index_filename, std::vector<pisa::Query> const& queries)
+{
+    Index index(MemorySource::mapped_file(index_filename));
+    auto accumulate_size = [&](auto sum, auto term_id) { return sum + index[term_id].size(); };
+    for (auto const& query: queries) {
+        auto count = std::accumulate(query.terms.begin(), query.terms.end(), 0, accumulate_size);
+        std::cout << count << '\n';
+    }
+}
 
 int main(int argc, char** argv)
 {
     spdlog::drop("");
     spdlog::set_default_logger(spdlog::stderr_color_mt(""));
-    std::string input_basename;
 
-    CLI::App app{"Counts all postings in the index."};
-    app.add_option("-c,--collection", input_basename, "Collection basename")->required();
+    App<arg::Index, arg::Query<arg::QueryMode::Unranked>> app{
+        "Extracts posting counts from an inverted index."};
     CLI11_PARSE(app, argc, argv);
 
-    binary_collection coll((input_basename + ".docs").c_str());
-    auto firstseq = *coll.begin();
-    if (firstseq.size() != 1) {
-        throw std::invalid_argument("First sequence should only contain number of documents");
+    /**/
+    if (false) {
+#define LOOP_BODY(R, DATA, T)                                                  \
+    }                                                                          \
+    else if (app.index_encoding() == BOOST_PP_STRINGIZE(T))                    \
+    {                                                                          \
+        extract<BOOST_PP_CAT(T, _index)>(app.index_filename(), app.queries()); \
+        /**/
+        BOOST_PP_SEQ_FOR_EACH(LOOP_BODY, _, PISA_INDEX_TYPES);
+#undef LOOP_BODY
+
+    } else {
+        spdlog::error("Unknown type {}", app.index_encoding());
     }
 
-    std::size_t count = -1;  // Takes care of the first 'fake' sequence
-    for (auto&& p: coll) {
-        count += p.size();
-    }
-
-    std::cout << count << '\n';
     return 0;
 }


### PR DESCRIPTION
This is a more useful posting counting tool, which counts postings from queries (sums up terms). You can easily count all postings by piping all terms or range of IDs.

It's only implemented for a compressed index because at this moment the uncompressed binary format doesn't support random access, so this is kind of pointless.