### PR TITLE
Return times when extracting taily scores

### DIFF
--- a/include/pisa/taily_stats.hpp
+++ b/include/pisa/taily_stats.hpp
@@ -11,6 +11,7 @@
 #include "memory_source.hpp"
 #include "query/queries.hpp"
 #include "scorer/scorer.hpp"
+#include "timer.hpp"
 #include "type_safe.hpp"
 #include "util/progress.hpp"
 #include "vec_map.hpp"
@@ -161,7 +162,9 @@ void taily_score_shards(
             std::back_inserter(shards),
             [query_idx](
                 auto&& shard, auto&& queries) { return shard.query_stats(queries[query_idx]); });
-        func(taily::score_shards(global, shards, k));
+        auto [scores, time] = run_with_timer_ret<std::chrono::microseconds>(
+            [&] { return taily::score_shards(global, shards, k); });
+        func(scores, time);
     }
 }
 

--- a/test/cli/test_taily_stats.sh
+++ b/test/cli/test_taily_stats.sh
@@ -155,9 +155,12 @@ write_sizes () {
     count=$(cat $BATS_TMPDIR/scores | wc -l)
     [[ "$count" = "5" ]]
 
-    count=$(cat $BATS_TMPDIR/scores | jq '.|arrays' -c | wc -l)
+    count=$(cat $BATS_TMPDIR/scores | jq '.scores' -c | wc -l)
     [[ "$count" = "5" ]]
 
-    count=$(cat $BATS_TMPDIR/scores | jq 'select(.==[0.0,0.0,0.0,0.0])' -c | wc -l)
+    count=$(cat $BATS_TMPDIR/scores | jq '.time' -c | wc -l)
+    [[ "$count" = "5" ]]
+
+    count=$(cat $BATS_TMPDIR/scores | jq 'select(.scores==[0.0,0.0,0.0,0.0])' -c | wc -l)
     [[ "$count" = "1" ]]
 }

--- a/tools/shards.cpp
+++ b/tools/shards.cpp
@@ -32,6 +32,18 @@ using pisa::TailyRankArgs;
 using pisa::TailyStatsArgs;
 using pisa::TailyThresholds;
 
+void print_taily_scores(std::vector<double> const& scores, std::chrono::microseconds time)
+{
+    std::cout << R"({"time":)" << time.count() << R"(,"scores":[)";
+    if (!scores.empty()) {
+        std::cout << scores.front();
+        std::for_each(std::next(scores.begin()), scores.end(), [](double score) {
+            std::cout << ',' << score;
+        });
+    }
+    std::cout << "]}\n";
+}
+
 int main(int argc, char** argv)
 {
     spdlog::drop("");
@@ -148,16 +160,7 @@ int main(int argc, char** argv)
                 taily_rank_args.queries(),
                 shard_queries,
                 taily_rank_args.k(),
-                [](auto&& scores) {
-                    std::cout << '[';
-                    if (!scores.empty()) {
-                        std::cout << scores.front();
-                        std::for_each(std::next(scores.begin()), scores.end(), [](double score) {
-                            std::cout << ',' << score;
-                        });
-                    }
-                    std::cout << "]\n";
-                });
+                print_taily_scores);
         }
         if (taily_thresholds->parsed()) {
             auto shards = resolve_shards(taily_thresholds_args.stats());


### PR DESCRIPTION
Just a small extension of the existing tool. Instead of extracting only scores, it also gives the time in microseconds of how long it took to compute the scores.