### PR TITLE
Add patch for accepting non-trec identifiers from WARC files

### DIFF
--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -89,7 +89,8 @@ record_parser(std::string const& type, std::istream& is)
                         if (rec.has_trecid()) {
                             return std::make_optional<Document_Record>(
                                 rec.trecid(), rec.content(), rec.url());
-                        } else if (rec.has_recordid()) {
+                        }
+                        if (rec.has_recordid()) {
                             return std::make_optional<Document_Record>(
                                 rec.recordid(), rec.content(), rec.url());
                         } 

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -89,9 +89,13 @@ record_parser(std::string const& type, std::istream& is)
                         if (rec.has_trecid()) {
                             return std::make_optional<Document_Record>(
                                 rec.trecid(), rec.content(), rec.url());
-                        } else {
+                        } else if (rec.has_recordid()) {
                             return std::make_optional<Document_Record>(
                                 rec.recordid(), rec.content(), rec.url());
+                        } else {
+                            // This should be unreachable
+                            spdlog::warn("Skipped invalid record: No warc-trec-id or warc-record-id...");
+                            return std::optional<Document_Record>{};
                         }
                     },
                     [](warcpp::Error const& error) {

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -92,11 +92,10 @@ record_parser(std::string const& type, std::istream& is)
                         } else if (rec.has_recordid()) {
                             return std::make_optional<Document_Record>(
                                 rec.recordid(), rec.content(), rec.url());
-                        } else {
-                            // This should be unreachable
-                            spdlog::warn("Skipped invalid record: No warc-trec-id or warc-record-id...");
-                            return std::optional<Document_Record>{};
-                        }
+                        } 
+                        // This should be unreachable
+                        spdlog::warn("Skipped invalid record: No warc-trec-id or warc-record-id...");
+                        return std::optional<Document_Record>{};
                     },
                     [](warcpp::Error const& error) {
                         spdlog::warn("Skipped invalid record: {}", error);

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -86,8 +86,13 @@ record_parser(std::string const& type, std::istream& is)
                             return std::optional<Document_Record>{};
                         }
                         // TODO(michal): use std::move
-                        return std::make_optional<Document_Record>(
-                            rec.trecid(), rec.content(), rec.url());
+                        if (rec.has_trecid()) {
+                            return std::make_optional<Document_Record>(
+                                rec.trecid(), rec.content(), rec.url());
+                        } else {
+                            return std::make_optional<Document_Record>(
+                                rec.recordid(), rec.content(), rec.url());
+                        }
                     },
                     [](warcpp::Error const& error) {
                         spdlog::warn("Skipped invalid record: {}", error);


### PR DESCRIPTION
Fixes #397 

Changes proposed in this pull request:

- Uses WARC-Record-ID instead of WARC-TREC-ID where the latter is not available.
- Depends on pending PR here: https://github.com/pisa-engine/warcpp/pull/10
- Will require the submodule update prior to merge
