### PR TITLE
Move forward index builder implementation to cpp

### DIFF
--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -30,7 +30,7 @@ add_library(MaskedVByte STATIC ${CMAKE_CURRENT_SOURCE_DIR}/MaskedVByte/src/varin
 
 # Add QMX
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/QMX EXCLUDE_FROM_ALL)
-target_compile_options(QMX INTERFACE -Wno-implicit-fallthrough)
+target_compile_options(QMX INTERFACE -Wno-unused-parameter -Wno-implicit-fallthrough)
 
 # Add mio
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/mio EXCLUDE_FROM_ALL)

--- a/include/pisa/algorithm.hpp
+++ b/include/pisa/algorithm.hpp
@@ -66,7 +66,7 @@ OutputIt transform(
 /// execution is not supported.
 template <class ExecutionPolicy, class ForwardIt1, class ForwardIt2, class OutputIt, class BinaryOperation>
 OutputIt transform(
-    ExecutionPolicy&& policy,
+    [[maybe_unused]] ExecutionPolicy&& policy,
     ForwardIt1 first1,
     ForwardIt1 last1,
     ForwardIt2 first2,
@@ -82,7 +82,7 @@ OutputIt transform(
 }
 
 template <class ExecutionPolicy, class RandomIt>
-void sort(ExecutionPolicy&& policy, RandomIt first, RandomIt last)
+void sort([[maybe_unused]] ExecutionPolicy&& policy, RandomIt first, RandomIt last)
 {
 #if defined(_LIBCPP_HAS_PARALLEL_ALGORITHMS)
     auto std_policy = pisa::execution::to_std(policy);
@@ -93,7 +93,7 @@ void sort(ExecutionPolicy&& policy, RandomIt first, RandomIt last)
 }
 
 template <class ExecutionPolicy, class RandomIt, class Compare>
-void sort(ExecutionPolicy&& policy, RandomIt first, RandomIt last, Compare comp)
+void sort([[maybe_unused]] ExecutionPolicy&& policy, RandomIt first, RandomIt last, Compare comp)
 {
 #if defined(_LIBCPP_HAS_PARALLEL_ALGORITHMS)
     auto std_policy = pisa::execution::to_std(policy);
@@ -104,7 +104,8 @@ void sort(ExecutionPolicy&& policy, RandomIt first, RandomIt last, Compare comp)
 }
 
 template <class ExecutionPolicy, class ForwardIt, class UnaryFunction2>
-void for_each(ExecutionPolicy&& policy, ForwardIt first, ForwardIt last, UnaryFunction2 f)
+void for_each(
+    [[maybe_unused]] ExecutionPolicy&& policy, ForwardIt first, ForwardIt last, UnaryFunction2 f)
 {
 #if defined(_LIBCPP_HAS_PARALLEL_ALGORITHMS)
     auto std_policy = pisa::execution::to_std(policy);

--- a/include/pisa/compress.hpp
+++ b/include/pisa/compress.hpp
@@ -11,7 +11,6 @@
 #include <spdlog/sinks/stdout_color_sinks.h>
 #include <spdlog/spdlog.h>
 
-#include "configuration.hpp"
 #include "ensure.hpp"
 #include "index_types.hpp"
 #include "linear_quantizer.hpp"
@@ -36,8 +35,6 @@ void dump_index_specific_stats(pisa::pefuniform_index const& coll, std::string c
 
 void dump_index_specific_stats(pisa::pefopt_index const& coll, std::string const& type)
 {
-    auto const& conf = pisa::configuration::get();
-
     uint64_t length_threshold = 4096;
     double long_postings = 0;
     double docs_partitions = 0;

--- a/include/pisa/forward_index_builder.hpp
+++ b/include/pisa/forward_index_builder.hpp
@@ -1,44 +1,31 @@
 #pragma once
 
-#include <algorithm>
 #include <cctype>
-#include <fstream>
 #include <functional>
-#include <numeric>
 #include <optional>
-#include <sstream>
-#include <stack>
 #include <string>
-#include <vector>
 
 #include <boost/filesystem.hpp>
-#include <gsl/gsl_assert>
-#include <range/v3/range/conversion.hpp>
-#include <range/v3/view/iota.hpp>
-#include <range/v3/view/transform.hpp>
-#include <range/v3/view/zip.hpp>
-#include <spdlog/fmt/ostr.h>
-#include <spdlog/spdlog.h>
-#include <tbb/concurrent_queue.h>
-#include <tbb/task_group.h>
 
-#include "binary_collection.hpp"
 #include "document_record.hpp"
-#include "io.hpp"
-#include "payload_vector.hpp"
 #include "query/term_processor.hpp"
-#include "tokenizer.hpp"
 #include "type_safe.hpp"
 
 namespace pisa {
 
-using process_term_function_type = std::function<std::string(std::string)>;
 using process_content_function_type =
     std::function<void(std::string&&, std::function<void(std::string&&)>)>;
 
 class Forward_Index_Builder {
   public:
     using read_record_function_type = std::function<std::optional<Document_Record>(std::istream&)>;
+
+    struct Batch_Process {
+        std::ptrdiff_t batch_number;
+        std::vector<Document_Record> records;
+        Document_Id first_document;
+        std::string const& output_file;
+    };
 
     template <typename Iterator>
     static std::ostream& write_document(std::ostream& os, Iterator first, Iterator last)
@@ -49,299 +36,43 @@ class Forward_Index_Builder {
         return os;
     }
 
-    static std::ostream& write_header(std::ostream& os, uint32_t document_count)
-    {
-        return write_document(os, &document_count, std::next(&document_count));
-    }
+    /// Writes the first sequence, which contains only the number of documents.
+    static std::ostream& write_header(std::ostream& os, std::uint32_t document_count);
 
+    /// Resolves the batch file path for the given batch number.
     [[nodiscard]] static auto
-    batch_file(std::string const& output_file, std::ptrdiff_t batch_number) noexcept -> std::string
-    {
-        std::ostringstream os;
-        os << output_file << ".batch." << batch_number;
-        return os.str();
-    }
+    batch_file(std::string const& output_file, std::ptrdiff_t batch_number) noexcept -> std::string;
 
-    struct Batch_Process {
-        std::ptrdiff_t batch_number;
-        std::vector<Document_Record> records;
-        Document_Id first_document;
-        std::string const& output_file;
-    };
+    /// Given a mapping from ID to term, constructs a mapping from term to ID.
+    [[nodiscard]] static auto reverse_mapping(std::vector<std::string>&& terms)
+        -> std::unordered_map<std::string, Term_Id>;
 
+    /// Collects all unique terms from batches into a vector.
+    [[nodiscard]] static auto collect_terms(std::string const& basename, std::ptrdiff_t batch_count)
+        -> std::vector<std::string>;
+
+    /// Processes a single batch.
     void
     run(Batch_Process bp,
-        process_term_function_type process_term,
-        process_content_function_type process_content) const
-    {
-        spdlog::debug(
-            "[Batch {}] Processing documents [{}, {})",
-            bp.batch_number,
-            bp.first_document,
-            bp.first_document + bp.records.size());
-        auto basename = batch_file(bp.output_file, bp.batch_number);
+        TermTransformer process_term,
+        process_content_function_type process_content) const;
 
-        std::ofstream os(basename);
-        std::ofstream title_os(basename + ".documents");
-        std::ofstream url_os(basename + ".urls");
-        std::ofstream term_os(basename + ".terms");
-        write_header(os, bp.records.size());
+    /// Merges batches.
+    void
+    merge(std::string const& basename, std::ptrdiff_t document_count, std::ptrdiff_t batch_count) const;
 
-        std::map<std::string, uint32_t> map;
-
-        for (auto&& record: bp.records) {
-            title_os << record.title() << '\n';
-            url_os << record.url() << '\n';
-
-            std::vector<uint32_t> term_ids;
-
-            auto process = [&](auto&& term) {
-                term = process_term(std::move(term));
-                uint32_t id = 0;
-                if (auto pos = map.find(term); pos != map.end()) {
-                    id = pos->second;
-                } else {
-                    id = map.size();
-                    map[term] = id;
-                    term_os << term << '\n';
-                }
-                term_ids.push_back(id);
-            };
-            process_content(std::move(record.content()), process);
-            write_document(os, term_ids.begin(), term_ids.end());
-        }
-        spdlog::info(
-            "[Batch {}] Processed documents [{}, {})",
-            bp.batch_number,
-            bp.first_document,
-            bp.first_document + bp.records.size());
-    }
-
-    [[nodiscard]] static auto reverse_mapping(std::vector<std::string>&& terms)
-        -> std::unordered_map<std::string, Term_Id>
-    {
-        std::unordered_map<std::string, Term_Id> mapping;
-        Term_Id term_id{0};
-        for (std::string& term: terms) {
-            mapping.emplace(std::move(term), term_id);
-            ++term_id;
-        }
-        return mapping;
-    }
-
-    [[nodiscard]] static auto collect_terms(std::string const& basename, std::ptrdiff_t batch_count)
-    {
-        struct Term_Span {
-            size_t first;
-            size_t last;
-            size_t lvl;
-        };
-        std::stack<Term_Span> spans;
-        std::vector<std::string> terms;
-        auto merge_spans = [&](Term_Span lhs, Term_Span rhs) {
-            Expects(lhs.last == rhs.first);
-            auto first = std::next(terms.begin(), lhs.first);
-            auto mid = std::next(terms.begin(), lhs.last);
-            auto last = std::next(terms.begin(), rhs.last);
-            std::inplace_merge(first, mid, last);
-            terms.erase(std::unique(first, last), last);
-            return Term_Span{lhs.first, terms.size(), lhs.lvl + 1};
-        };
-        auto push_span = [&](Term_Span s) {
-            while (not spans.empty() and spans.top().lvl == s.lvl) {
-                s = merge_spans(spans.top(), s);
-                spans.pop();
-            }
-            spans.push(s);
-        };
-
-        spdlog::info("Collecting terms");
-        for (auto batch: ranges::views::iota(0, batch_count)) {
-            spdlog::debug("[Collecting terms] Batch {}/{}", batch, batch_count);
-            auto mid = terms.size();
-            std::ifstream terms_is(batch_file(basename, batch) + ".terms");
-            std::string term;
-            while (std::getline(terms_is, term)) {
-                terms.push_back(term);
-            }
-            std::sort(std::next(terms.begin(), mid), terms.end());
-            push_span(Term_Span{mid, terms.size(), 0U});
-        }
-        while (spans.size() > 1) {
-            auto rhs = spans.top();
-            spans.pop();
-            auto lhs = spans.top();
-            spans.pop();
-            spans.push(merge_spans(lhs, rhs));
-        }
-        terms.shrink_to_fit();
-        return terms;
-    }
-
-    void merge(std::string const& basename, std::ptrdiff_t document_count, std::ptrdiff_t batch_count) const
-    {
-        std::ofstream term_os(basename + ".terms");
-
-        {
-            spdlog::info("Merging titles");
-            std::ofstream title_os(basename + ".documents");
-            for (auto batch: ranges::views::iota(0, batch_count)) {
-                spdlog::debug("[Merging titles] Batch {}/{}", batch, batch_count);
-                std::ifstream title_is(batch_file(basename, batch) + ".documents");
-                title_os << title_is.rdbuf();
-            }
-        }
-        {
-            spdlog::info("Creating document lexicon");
-            std::ifstream title_is(basename + ".documents");
-            encode_payload_vector(
-                std::istream_iterator<io::Line>(title_is), std::istream_iterator<io::Line>())
-                .to_file(basename + ".doclex");
-        }
-        {
-            spdlog::info("Merging URLs");
-            std::ofstream url_os(basename + ".urls");
-            for (auto batch: ranges::views::iota(0, batch_count)) {
-                spdlog::debug("[Merging URLs] Batch {}/{}", batch, batch_count);
-                std::ifstream url_is(batch_file(basename, batch) + ".urls");
-                url_os << url_is.rdbuf();
-            }
-        }
-
-        auto terms = collect_terms(basename, batch_count);
-
-        spdlog::info("Writing terms");
-        for (auto const& term: terms) {
-            term_os << term << '\n';
-        }
-        encode_payload_vector(terms.begin(), terms.end()).to_file(basename + ".termlex");
-
-        spdlog::info("Mapping terms");
-        auto term_mapping = reverse_mapping(std::move(terms));
-
-        spdlog::info("Remapping IDs");
-        for (auto batch: ranges::views::iota(0, batch_count)) {
-            spdlog::debug("[Remapping IDs] Batch {}/{}", batch, batch_count);
-            auto batch_terms = io::read_string_vector(batch_file(basename, batch) + ".terms");
-            std::vector<Term_Id> mapping(batch_terms.size());
-            std::transform(
-                batch_terms.begin(), batch_terms.end(), mapping.begin(), [&](auto const& bterm) {
-                    return term_mapping[bterm];
-                });
-            writable_binary_collection coll(batch_file(basename, batch).c_str());
-            for (auto doc_iter = ++coll.begin(); doc_iter != coll.end(); ++doc_iter) {
-                for (auto& term_id: *doc_iter) {
-                    term_id = mapping[term_id].as_int();
-                }
-            }
-        }
-        term_mapping.clear();
-
-        spdlog::info("Concatenating batches");
-        std::ofstream os(basename);
-        write_header(os, document_count);
-        for (auto batch: ranges::views::iota(0, batch_count)) {
-            spdlog::debug("[Concatenating batches] Batch {}/{}", batch, batch_count);
-            std::ifstream is(batch_file(basename, batch));
-            is.ignore(8);
-            os << is.rdbuf();
-        }
-
-        spdlog::info("Success.");
-    }
-
-    template <typename TermProcessorConstruct>
+    /// Builds a forward index.
     void build(
         std::istream& is,
         std::string const& output_file,
         read_record_function_type next_record,
-        TermProcessorConstruct&& term_processor,
+        TermTransformerBuilder term_transformer_builder,
         process_content_function_type process_content,
         std::ptrdiff_t batch_size,
-        std::size_t threads) const
-    {
-        if (threads < 2) {
-            spdlog::error("Building forward index requires at least 2 threads");
-            std::abort();
-        }
-        Document_Id first_document{0};
-        std::ptrdiff_t batch_number = 0;
+        std::size_t threads) const;
 
-        std::vector<Document_Record> record_batch;
-        tbb::task_group batch_group;
-        tbb::concurrent_bounded_queue<int> queue;
-        queue.set_capacity((threads - 1) * 2);
-        while (true) {
-            std::optional<Document_Record> record = std::nullopt;
-            if (not(record = next_record(is))) {
-                auto last_batch_size = record_batch.size();
-                auto batch_process = [&] {
-                    return Batch_Process{
-                        batch_number, std::move(record_batch), first_document, output_file};
-                };
-                queue.push(0);
-                batch_group.run([bp = batch_process(),
-                                 term_processor = term_processor(),
-                                 this,
-                                 &queue,
-                                 &process_content]() {
-                    run(bp, std::move(term_processor), process_content);
-                    int x;
-                    queue.try_pop(x);
-                });
-                ++batch_number;
-                first_document += last_batch_size;
-                break;
-            }
-            spdlog::debug("Parsed document {}", record->title());
-            record_batch.push_back(std::move(*record));  // AppleClang is missing value() in
-                                                         // Optional
-            if (record_batch.size() == batch_size) {
-                auto batch_process = [&] {
-                    return Batch_Process{
-                        batch_number, std::move(record_batch), first_document, output_file};
-                };
-                queue.push(0);
-                batch_group.run([bp = batch_process(),
-                                 term_processor = term_processor(),
-                                 this,
-                                 &queue,
-                                 &process_content]() {
-                    run(bp, std::move(term_processor), process_content);
-                    int x;
-                    queue.try_pop(x);
-                });
-                ++batch_number;
-                first_document += batch_size;
-                record_batch = std::vector<Document_Record>();
-            }
-        }
-        batch_group.wait();
-        merge(output_file, first_document.as_int(), batch_number);
-        remove_batches(output_file, batch_number);
-    }
-
-    void try_remove(boost::filesystem::path const& file) const
-    {
-        using boost::filesystem::remove;
-        try {
-            remove(file);
-        } catch (...) {
-            spdlog::warn("Unable to remove temporary batch file {}", file.c_str());
-        }
-    }
-
-    void remove_batches(std::string const& basename, std::ptrdiff_t batch_count) const
-    {
-        using boost::filesystem::path;
-        for (auto batch: ranges::views::iota(0, batch_count)) {
-            auto batch_basename = batch_file(basename, batch);
-            try_remove(path{batch_basename + ".documents"});
-            try_remove(path{batch_basename + ".terms"});
-            try_remove(path{batch_basename + ".urls"});
-            try_remove(path{batch_basename});
-        }
-    }
+    /// Removes all intermediate batches.
+    void remove_batches(std::string const& basename, std::ptrdiff_t batch_count) const;
 };
 
 }  // namespace pisa

--- a/include/pisa/query/algorithm/ranked_or_taat_query.hpp
+++ b/include/pisa/query/algorithm/ranked_or_taat_query.hpp
@@ -17,7 +17,6 @@ class ranked_or_taat_query {
     template <typename CursorRange, typename Acc>
     void operator()(CursorRange&& cursors, uint64_t max_docid, Acc&& accumulator)
     {
-        using Cursor = typename std::decay_t<CursorRange>::value_type;
         if (cursors.empty()) {
             return;
         }

--- a/include/pisa/query/query_stemmer.hpp
+++ b/include/pisa/query/query_stemmer.hpp
@@ -3,15 +3,18 @@
 #include <sstream>
 #include <string>
 
+#include <boost/algorithm/string/join.hpp>
+
 #include "query/queries.hpp"
 #include "query/term_processor.hpp"
 #include "tokenizer.hpp"
-#include <boost/algorithm/string/join.hpp>
+
 namespace pisa {
+
 class QueryStemmer {
   public:
     explicit QueryStemmer(std::optional<std::string> const& stemmer_name)
-        : m_stemmer(term_processor_builder(stemmer_name)())
+        : m_stemmer(term_transformer_builder(stemmer_name)())
     {}
     std::string operator()(std::string const& query_string)
     {
@@ -30,6 +33,7 @@ class QueryStemmer {
         return tokenized_query.str();
     }
 
-    Stemmer_t m_stemmer;
+    TermTransformer m_stemmer;
 };
+
 }  // namespace pisa

--- a/include/pisa/query/term_processor.hpp
+++ b/include/pisa/query/term_processor.hpp
@@ -11,9 +11,10 @@
 namespace pisa {
 
 using term_id_type = uint32_t;
-using Stemmer_t = std::function<std::string(std::string)>;
+using TermTransformer = std::function<std::string(std::string)>;
+using TermTransformerBuilder = std::function<TermTransformer()>;
 
-auto term_processor_builder(std::optional<std::string> const& type) -> std::function<Stemmer_t()>;
+auto term_transformer_builder(std::optional<std::string> const& type) -> TermTransformerBuilder;
 
 class TermProcessor {
   private:
@@ -36,7 +37,7 @@ class TermProcessor {
         };
 
         // Implements '_to_id' method.
-        _to_id = [=](auto str) { return to_id(term_processor_builder(stemmer_type)()(str)); };
+        _to_id = [=](auto str) { return to_id(term_transformer_builder(stemmer_type)()(str)); };
         // Loads stopwords.
         if (stopwords_filename) {
             std::ifstream is(*stopwords_filename);

--- a/include/pisa/scorer/quantized.hpp
+++ b/include/pisa/scorer/quantized.hpp
@@ -11,10 +11,9 @@ namespace pisa {
 template <typename Wand>
 struct quantized: public index_scorer<Wand> {
     using index_scorer<Wand>::index_scorer;
-    term_scorer_t term_scorer(uint64_t term_id) const
+    term_scorer_t term_scorer([[maybe_unused]] uint64_t term_id) const
     {
-        auto s = [](uint32_t doc, uint32_t freq) { return freq; };
-        return s;
+        return []([[maybe_unused]] uint32_t doc, uint32_t freq) { return freq; };
     }
 };
 

--- a/include/pisa/sequence/partitioned_sequence.hpp
+++ b/include/pisa/sequence/partitioned_sequence.hpp
@@ -5,7 +5,6 @@
 
 #include "codec/compact_elias_fano.hpp"
 #include "codec/integer_codes.hpp"
-#include "configuration.hpp"
 #include "global_parameters.hpp"
 #include "optimal_partition.hpp"
 #include "sequence/indexed_sequence.hpp"
@@ -340,8 +339,6 @@ struct partitioned_sequence {
         double eps3 = 0.01)
     {
         std::vector<uint32_t> partition;
-
-        auto const& conf = configuration::get();
 
         if (base_sequence_type::bitsize(params, universe, n) < 2 * fix_cost) {
             partition.push_back(n);

--- a/include/pisa/wand_data_compressed.hpp
+++ b/include/pisa/wand_data_compressed.hpp
@@ -109,7 +109,7 @@ class wand_data_compressed {
         float add_sequence(
             binary_freq_collection::sequence const& seq,
             binary_freq_collection const& coll,
-            std::vector<uint32_t> const& doc_lens,
+            [[maybe_unused]] std::vector<uint32_t> const& doc_lens,
             float avg_len,
             Scorer scorer,
             BlockSize block_size)
@@ -130,7 +130,7 @@ class wand_data_compressed {
             return max_term_weight.back();
         }
 
-        void quantize_block_max_term_weights(float index_max_term_weight) {}
+        void quantize_block_max_term_weights([[maybe_unused]] float index_max_term_weight) {}
 
         void build(wand_data_compressed& wdata)
         {
@@ -202,10 +202,10 @@ class wand_data_compressed {
         uint64_t PISA_FLATTEN_FUNC docid() const { return m_cur_docid; }
 
       private:
+        compact_elias_fano::enumerator m_docs_enum;
+        float m_max_term_weight{0};
         uint64_t m_cur_docid{0};
         uint64_t m_cur_score_index{0};
-        float m_max_term_weight{0};
-        compact_elias_fano::enumerator m_docs_enum;
     };
 
     uint64_t size() const { return m_docs_sequences.size(); }

--- a/include/pisa/wand_data_range.hpp
+++ b/include/pisa/wand_data_range.hpp
@@ -57,8 +57,8 @@ class wand_data_range {
         template <typename Scorer>
         float add_sequence(
             binary_freq_collection::sequence const& term_seq,
-            binary_freq_collection const& coll,
-            std::vector<uint32_t> const& doc_lens,
+            [[maybe_unused]] binary_freq_collection const& coll,
+            [[maybe_unused]] std::vector<uint32_t> const& doc_lens,
             float avg_len,
             Scorer scorer,
             [[maybe_unused]] BlockSize block_size)

--- a/include/pisa/wand_data_raw.hpp
+++ b/include/pisa/wand_data_raw.hpp
@@ -34,7 +34,7 @@ class wand_data_raw {
         float add_sequence(
             binary_freq_collection::sequence const& seq,
             binary_freq_collection const& coll,
-            std::vector<uint32_t> const& doc_lens,
+            [[maybe_unused]] std::vector<uint32_t> const& doc_lens,
             float avg_len,
             Scorer scorer,
             BlockSize block_size)

--- a/include/pisa/wand_utils.hpp
+++ b/include/pisa/wand_utils.hpp
@@ -55,7 +55,7 @@ std::pair<std::vector<uint32_t>, std::vector<float>> static_block_partition(
 
 template <typename Scorer>
 std::pair<std::vector<uint32_t>, std::vector<float>> variable_block_partition(
-    binary_freq_collection const& coll,
+    [[maybe_unused]] binary_freq_collection const& coll,
     binary_freq_collection::sequence const& seq,
     Scorer scorer,
     const float lambda,

--- a/src/forward_index_builder.cpp
+++ b/src/forward_index_builder.cpp
@@ -1,0 +1,302 @@
+#include "pisa/forward_index_builder.hpp"
+
+#include <map>
+#include <sstream>
+
+#include <range/v3/view/iota.hpp>
+#include <spdlog/fmt/ostr.h>
+#include <spdlog/spdlog.h>
+#include <tbb/concurrent_queue.h>
+#include <tbb/task_group.h>
+
+#include "binary_collection.hpp"
+
+namespace pisa {
+
+std::ostream& Forward_Index_Builder::write_header(std::ostream& os, uint32_t document_count)
+{
+    return Forward_Index_Builder::write_document(os, &document_count, std::next(&document_count));
+}
+
+auto Forward_Index_Builder::batch_file(std::string const& output_file, std::ptrdiff_t batch_number) noexcept
+    -> std::string
+{
+    std::ostringstream os;
+    os << output_file << ".batch." << batch_number;
+    return os.str();
+}
+
+void Forward_Index_Builder::run(
+    Batch_Process bp, TermTransformer process_term, process_content_function_type process_content) const
+{
+    spdlog::debug(
+        "[Batch {}] Processing documents [{}, {})",
+        bp.batch_number,
+        bp.first_document,
+        bp.first_document + bp.records.size());
+    auto basename = batch_file(bp.output_file, bp.batch_number);
+
+    std::ofstream os(basename);
+    std::ofstream title_os(basename + ".documents");
+    std::ofstream url_os(basename + ".urls");
+    std::ofstream term_os(basename + ".terms");
+    write_header(os, bp.records.size());
+
+    std::map<std::string, uint32_t> map;
+
+    for (auto&& record: bp.records) {
+        title_os << record.title() << '\n';
+        url_os << record.url() << '\n';
+
+        std::vector<uint32_t> term_ids;
+
+        auto process = [&](auto&& term) {
+            term = process_term(std::move(term));
+            uint32_t id = 0;
+            if (auto pos = map.find(term); pos != map.end()) {
+                id = pos->second;
+            } else {
+                id = map.size();
+                map[term] = id;
+                term_os << term << '\n';
+            }
+            term_ids.push_back(id);
+        };
+        process_content(std::move(record.content()), process);
+        write_document(os, term_ids.begin(), term_ids.end());
+    }
+    spdlog::info(
+        "[Batch {}] Processed documents [{}, {})",
+        bp.batch_number,
+        bp.first_document,
+        bp.first_document + bp.records.size());
+}
+
+auto Forward_Index_Builder::reverse_mapping(std::vector<std::string>&& terms)
+    -> std::unordered_map<std::string, Term_Id>
+{
+    std::unordered_map<std::string, Term_Id> mapping;
+    Term_Id term_id{0};
+    for (std::string& term: terms) {
+        mapping.emplace(std::move(term), term_id);
+        ++term_id;
+    }
+    return mapping;
+}
+
+auto Forward_Index_Builder::collect_terms(std::string const& basename, std::ptrdiff_t batch_count)
+    -> std::vector<std::string>
+{
+    struct Term_Span {
+        size_t first;
+        size_t last;
+        size_t lvl;
+    };
+    std::stack<Term_Span> spans;
+    std::vector<std::string> terms;
+    auto merge_spans = [&](Term_Span lhs, Term_Span rhs) {
+        Expects(lhs.last == rhs.first);
+        auto first = std::next(terms.begin(), lhs.first);
+        auto mid = std::next(terms.begin(), lhs.last);
+        auto last = std::next(terms.begin(), rhs.last);
+        std::inplace_merge(first, mid, last);
+        terms.erase(std::unique(first, last), last);
+        return Term_Span{lhs.first, terms.size(), lhs.lvl + 1};
+    };
+    auto push_span = [&](Term_Span s) {
+        while (not spans.empty() and spans.top().lvl == s.lvl) {
+            s = merge_spans(spans.top(), s);
+            spans.pop();
+        }
+        spans.push(s);
+    };
+
+    spdlog::info("Collecting terms");
+    for (auto batch: ranges::views::iota(0, batch_count)) {
+        spdlog::debug("[Collecting terms] Batch {}/{}", batch, batch_count);
+        auto mid = terms.size();
+        std::ifstream terms_is(batch_file(basename, batch) + ".terms");
+        std::string term;
+        while (std::getline(terms_is, term)) {
+            terms.push_back(term);
+        }
+        std::sort(std::next(terms.begin(), mid), terms.end());
+        push_span(Term_Span{mid, terms.size(), 0U});
+    }
+    while (spans.size() > 1) {
+        auto rhs = spans.top();
+        spans.pop();
+        auto lhs = spans.top();
+        spans.pop();
+        spans.push(merge_spans(lhs, rhs));
+    }
+    terms.shrink_to_fit();
+    return terms;
+}
+
+void Forward_Index_Builder::merge(
+    std::string const& basename, std::ptrdiff_t document_count, std::ptrdiff_t batch_count) const
+{
+    std::ofstream term_os(basename + ".terms");
+
+    {
+        spdlog::info("Merging titles");
+        std::ofstream title_os(basename + ".documents");
+        for (auto batch: ranges::views::iota(0, batch_count)) {
+            spdlog::debug("[Merging titles] Batch {}/{}", batch, batch_count);
+            std::ifstream title_is(batch_file(basename, batch) + ".documents");
+            title_os << title_is.rdbuf();
+        }
+    }
+    {
+        spdlog::info("Creating document lexicon");
+        std::ifstream title_is(basename + ".documents");
+        encode_payload_vector(
+            std::istream_iterator<io::Line>(title_is), std::istream_iterator<io::Line>())
+            .to_file(basename + ".doclex");
+    }
+    {
+        spdlog::info("Merging URLs");
+        std::ofstream url_os(basename + ".urls");
+        for (auto batch: ranges::views::iota(0, batch_count)) {
+            spdlog::debug("[Merging URLs] Batch {}/{}", batch, batch_count);
+            std::ifstream url_is(batch_file(basename, batch) + ".urls");
+            url_os << url_is.rdbuf();
+        }
+    }
+
+    auto terms = collect_terms(basename, batch_count);
+
+    spdlog::info("Writing terms");
+    for (auto const& term: terms) {
+        term_os << term << '\n';
+    }
+    encode_payload_vector(terms.begin(), terms.end()).to_file(basename + ".termlex");
+
+    spdlog::info("Mapping terms");
+    auto term_mapping = reverse_mapping(std::move(terms));
+
+    spdlog::info("Remapping IDs");
+    for (auto batch: ranges::views::iota(0, batch_count)) {
+        spdlog::debug("[Remapping IDs] Batch {}/{}", batch, batch_count);
+        auto batch_terms = io::read_string_vector(batch_file(basename, batch) + ".terms");
+        std::vector<Term_Id> mapping(batch_terms.size());
+        std::transform(
+            batch_terms.begin(), batch_terms.end(), mapping.begin(), [&](auto const& bterm) {
+                return term_mapping[bterm];
+            });
+        writable_binary_collection coll(batch_file(basename, batch).c_str());
+        for (auto doc_iter = ++coll.begin(); doc_iter != coll.end(); ++doc_iter) {
+            for (auto& term_id: *doc_iter) {
+                term_id = mapping[term_id].as_int();
+            }
+        }
+    }
+    term_mapping.clear();
+
+    spdlog::info("Concatenating batches");
+    std::ofstream os(basename);
+    write_header(os, document_count);
+    for (auto batch: ranges::views::iota(0, batch_count)) {
+        spdlog::debug("[Concatenating batches] Batch {}/{}", batch, batch_count);
+        std::ifstream is(batch_file(basename, batch));
+        is.ignore(8);
+        os << is.rdbuf();
+    }
+
+    spdlog::info("Success.");
+}
+
+void Forward_Index_Builder::build(
+    std::istream& is,
+    std::string const& output_file,
+    read_record_function_type next_record,
+    TermTransformerBuilder term_transformer_builder,
+    process_content_function_type process_content,
+    std::ptrdiff_t batch_size,
+    std::size_t threads) const
+{
+    if (threads < 2) {
+        spdlog::error("Building forward index requires at least 2 threads");
+        std::abort();
+    }
+    Document_Id first_document{0};
+    std::ptrdiff_t batch_number = 0;
+
+    std::vector<Document_Record> record_batch;
+    tbb::task_group batch_group;
+    tbb::concurrent_bounded_queue<int> queue;
+    queue.set_capacity((threads - 1) * 2);
+    while (true) {
+        std::optional<Document_Record> record = std::nullopt;
+        if (not(record = next_record(is))) {
+            auto last_batch_size = record_batch.size();
+            auto batch_process = [&] {
+                return Batch_Process{
+                    batch_number, std::move(record_batch), first_document, output_file};
+            };
+            queue.push(0);
+            batch_group.run([bp = batch_process(),
+                             term_processor = term_transformer_builder(),
+                             this,
+                             &queue,
+                             &process_content]() {
+                run(bp, term_processor, process_content);
+                int x;
+                queue.try_pop(x);
+            });
+            ++batch_number;
+            first_document += last_batch_size;
+            break;
+        }
+        spdlog::debug("Parsed document {}", record->title());
+        record_batch.push_back(std::move(*record));  // AppleClang is missing value() in
+                                                     // Optional
+        if (record_batch.size() == batch_size) {
+            auto batch_process = [&] {
+                return Batch_Process{
+                    batch_number, std::move(record_batch), first_document, output_file};
+            };
+            queue.push(0);
+            batch_group.run([bp = batch_process(),
+                             term_processor = term_transformer_builder(),
+                             this,
+                             &queue,
+                             &process_content]() {
+                run(bp, term_processor, process_content);
+                int x;
+                queue.try_pop(x);
+            });
+            ++batch_number;
+            first_document += batch_size;
+            record_batch = std::vector<Document_Record>();
+        }
+    }
+    batch_group.wait();
+    merge(output_file, first_document.as_int(), batch_number);
+    remove_batches(output_file, batch_number);
+}
+
+void try_remove(boost::filesystem::path const& file)
+{
+    using boost::filesystem::remove;
+    try {
+        remove(file);
+    } catch (...) {
+        spdlog::warn("Unable to remove temporary batch file {}", file.c_str());
+    }
+}
+
+void Forward_Index_Builder::remove_batches(std::string const& basename, std::ptrdiff_t batch_count) const
+{
+    using boost::filesystem::path;
+    for (auto batch: ranges::views::iota(0, batch_count)) {
+        auto batch_basename = batch_file(basename, batch);
+        try_remove(path{batch_basename + ".documents"});
+        try_remove(path{batch_basename + ".terms"});
+        try_remove(path{batch_basename + ".urls"});
+        try_remove(path{batch_basename});
+    }
+}
+
+}  // namespace pisa

--- a/src/query/term_processor.cpp
+++ b/src/query/term_processor.cpp
@@ -6,10 +6,7 @@
 
 namespace pisa {
 
-using term_id_type = uint32_t;
-using Stemmer_t = std::function<std::string(std::string)>;
-
-auto term_processor_builder(std::optional<std::string> const& type) -> std::function<Stemmer_t()>
+auto term_transformer_builder(std::optional<std::string> const& type) -> TermTransformerBuilder
 {
     if (not type) {
         return [] {

--- a/test/test_forward_index_builder.cpp
+++ b/test/test_forward_index_builder.cpp
@@ -8,12 +8,14 @@
 #include <catch2/catch.hpp>
 #include <gsl/span>
 
+#include "binary_collection.hpp"
 #include "filesystem.hpp"
 #include "forward_index_builder.hpp"
 #include "parser.hpp"
 #include "parsing/html.hpp"
 #include "pisa_config.hpp"
 #include "temporary_directory.hpp"
+#include "tokenizer.hpp"
 
 using namespace boost::filesystem;
 using namespace pisa;

--- a/tools/app.hpp
+++ b/tools/app.hpp
@@ -431,12 +431,11 @@ namespace arg {
                                   "Assign IDs randomly. You can use --seed for deterministic "
                                   "results.")
                               ->needs(output);
-            auto mapping = methods->add_option(
+            methods->add_option(
                 "--from-mapping",
                 m_mapping,
                 "Use the mapping defined in this new-line delimited text file");
-            auto feature =
-                methods->add_option("--by-feature", m_feature, "Order by URLs from this file");
+            methods->add_option("--by-feature", m_feature, "Order by URLs from this file");
             auto bp = methods->add_flag(
                 "--recursive-graph-bisection,--bp", m_bp, "Use recursive graph bisection algorithm");
             methods->require_option(1);

--- a/tools/kth_threshold.cpp
+++ b/tools/kth_threshold.cpp
@@ -164,7 +164,6 @@ int main(int argc, const char** argv)
     std::string query_filename;
     std::optional<std::string> pairs_filename;
     std::optional<std::string> triples_filename;
-    size_t k;
     std::string index_filename;
     std::string wand_data_filename;
     bool quantized = false;

--- a/tools/parse_collection.cpp
+++ b/tools/parse_collection.cpp
@@ -74,7 +74,7 @@ int main(int argc, char** argv)
                 std::cin,
                 output_filename,
                 record_parser(format, std::cin),
-                term_processor_builder(stemmer),
+                term_transformer_builder(stemmer),
                 content_parser(content_parser_type),
                 batch_size,
                 threads);


### PR DESCRIPTION
Moves the implementation to a separate compilation unit for faster
compilation. It also includes some minor changes to eliminate most of
the compilation warnings.