### PR TITLE
Multiply block max score by term weight in cursor (#474)

### DIFF
--- a/include/pisa/cursor/block_max_scored_cursor.hpp
+++ b/include/pisa/cursor/block_max_scored_cursor.hpp
@@ -31,10 +31,7 @@ class BlockMaxScoredCursor: public MaxScoredCursor<Cursor> {
 
     [[nodiscard]] PISA_ALWAYSINLINE auto block_max_score() -> float
     {
-        // NOTE: we do not multiply because the algorithms explicitly multiply this by the value
-        // taken from `query_weight()` method of `ScoredCursor`. We might want to refactor this to
-        // be more consistent.
-        return m_wdata.score();
+        return m_wdata.score() * this->query_weight();
     }
 
     [[nodiscard]] PISA_ALWAYSINLINE auto block_max_docid() -> std::uint32_t

--- a/include/pisa/query/algorithm/block_max_maxscore_query.hpp
+++ b/include/pisa/query/algorithm/block_max_maxscore_query.hpp
@@ -59,8 +59,8 @@ struct block_max_maxscore_query {
                 if (ordered_cursors[i]->block_max_docid() < cur_doc) {
                     ordered_cursors[i]->block_max_next_geq(cur_doc);
                 }
-                block_upper_bound -= ordered_cursors[i]->max_score()
-                    - ordered_cursors[i]->block_max_score() * ordered_cursors[i]->query_weight();
+                block_upper_bound -=
+                    ordered_cursors[i]->max_score() - ordered_cursors[i]->block_max_score();
                 if (!m_topk.would_enter(score + block_upper_bound)) {
                     break;
                 }
@@ -71,11 +71,9 @@ struct block_max_maxscore_query {
                     ordered_cursors[i]->next_geq(cur_doc);
                     if (ordered_cursors[i]->docid() == cur_doc) {
                         auto s = ordered_cursors[i]->score();
-                        // score += s;
                         block_upper_bound += s;
                     }
-                    block_upper_bound -=
-                        ordered_cursors[i]->block_max_score() * ordered_cursors[i]->query_weight();
+                    block_upper_bound -= ordered_cursors[i]->block_max_score();
 
                     if (!m_topk.would_enter(score + block_upper_bound)) {
                         break;

--- a/include/pisa/query/algorithm/block_max_ranked_and_query.hpp
+++ b/include/pisa/query/algorithm/block_max_ranked_and_query.hpp
@@ -36,8 +36,7 @@ struct block_max_ranked_and_query {
             double block_upper_bound = 0;
             for (size_t block = 0; block < ordered_cursors.size(); ++block) {
                 ordered_cursors[block]->block_max_next_geq(candidate);
-                block_upper_bound += ordered_cursors[block]->block_max_score()
-                    * ordered_cursors[block]->query_weight();
+                block_upper_bound += ordered_cursors[block]->block_max_score();
             }
             if (m_topk.would_enter(block_upper_bound)) {
                 for (; candidate_list < ordered_cursors.size(); ++candidate_list) {

--- a/include/pisa/query/algorithm/block_max_wand_query.hpp
+++ b/include/pisa/query/algorithm/block_max_wand_query.hpp
@@ -67,8 +67,7 @@ struct block_max_wand_query {
                     ordered_cursors[i]->block_max_next_geq(pivot_id);
                 }
 
-                block_upper_bound +=
-                    ordered_cursors[i]->block_max_score() * ordered_cursors[i]->query_weight();
+                block_upper_bound += ordered_cursors[i]->block_max_score();
             }
 
             if (m_topk.would_enter(block_upper_bound)) {
@@ -81,7 +80,7 @@ struct block_max_wand_query {
                         }
                         float part_score = en->score();
                         score += part_score;
-                        block_upper_bound -= en->block_max_score() * en->query_weight() - part_score;
+                        block_upper_bound -= en->block_max_score() - part_score;
                         if (!m_topk.would_enter(block_upper_bound)) {
                             break;
                         }


### PR DESCRIPTION
We already do that for scores, and this is for consistency and simplicity. All uses of block_max_score in algorithms have been modified to take this change into account.

Fixes #474 