### PR TITLE
Move TemporaryDirectory to pisa namespace (#419)

### DIFF
--- a/include/pisa/block_freq_index.hpp
+++ b/include/pisa/block_freq_index.hpp
@@ -284,7 +284,7 @@ class block_freq_index {
         std::size_t m_num_docs = 0;
         std::size_t m_size = 0;
         std::vector<std::uint64_t> m_endpoints{};
-        Temporary_Directory tmp{};
+        TemporaryDirectory tmp{};
         std::ofstream m_postings_output;
         std::size_t m_postings_bytes_written{0};
     };

--- a/include/pisa/temporary_directory.hpp
+++ b/include/pisa/temporary_directory.hpp
@@ -1,33 +1,25 @@
 #pragma once
 
-#include <iostream>
+#include <boost/filesystem.hpp>
 
-#include "boost/filesystem.hpp"
+namespace pisa {
 
-struct Temporary_Directory {
-    Temporary_Directory()
-        : dir_(boost::filesystem::temp_directory_path() / boost::filesystem::unique_path())
-    {
-        if (boost::filesystem::exists(dir_)) {
-            boost::filesystem::remove_all(dir_);
-        }
-        boost::filesystem::create_directory(dir_);
-        std::cerr << "Created a tmp dir " << dir_.c_str() << '\n';
-    }
-    Temporary_Directory(Temporary_Directory const&) = default;
-    Temporary_Directory(Temporary_Directory&&) noexcept = default;
-    Temporary_Directory& operator=(Temporary_Directory const&) = default;
-    Temporary_Directory& operator=(Temporary_Directory&&) noexcept = default;
-    ~Temporary_Directory()
-    {
-        if (boost::filesystem::exists(dir_)) {
-            boost::filesystem::remove_all(dir_);
-        }
-        std::cerr << "Removed a tmp dir " << dir_.c_str() << '\n';
-    }
+/**
+ * RAII object that creates a temporary directory at creation and removes it when destructed.
+ */
+struct TemporaryDirectory {
+    TemporaryDirectory();
+    TemporaryDirectory(TemporaryDirectory const&);
+    TemporaryDirectory(TemporaryDirectory&&) noexcept;
+    TemporaryDirectory& operator=(TemporaryDirectory const&);
+    TemporaryDirectory& operator=(TemporaryDirectory&&) noexcept;
+    ~TemporaryDirectory();
 
-    [[nodiscard]] auto path() -> boost::filesystem::path const& { return dir_; }
+    /** Returns the path to the created directory. */
+    [[nodiscard]] auto path() -> boost::filesystem::path const&;
 
   private:
     boost::filesystem::path dir_;
 };
+
+};  // namespace pisa

--- a/src/temporary_directory.cpp
+++ b/src/temporary_directory.cpp
@@ -1,0 +1,35 @@
+#include "pisa/temporary_directory.hpp"
+
+#include <iostream>
+
+namespace pisa {
+
+TemporaryDirectory::TemporaryDirectory()
+    : dir_(boost::filesystem::temp_directory_path() / boost::filesystem::unique_path())
+{
+    if (boost::filesystem::exists(dir_)) {
+        boost::filesystem::remove_all(dir_);
+    }
+    boost::filesystem::create_directory(dir_);
+    std::cerr << "Created a tmp dir " << dir_.c_str() << '\n';
+}
+
+TemporaryDirectory::TemporaryDirectory(TemporaryDirectory const&) = default;
+TemporaryDirectory::TemporaryDirectory(TemporaryDirectory&&) noexcept = default;
+TemporaryDirectory& TemporaryDirectory::operator=(TemporaryDirectory const&) = default;
+TemporaryDirectory& TemporaryDirectory::operator=(TemporaryDirectory&&) noexcept = default;
+
+TemporaryDirectory::~TemporaryDirectory()
+{
+    if (boost::filesystem::exists(dir_)) {
+        boost::filesystem::remove_all(dir_);
+    }
+    std::cerr << "Removed a tmp dir " << dir_.c_str() << '\n';
+}
+
+auto TemporaryDirectory::path() -> boost::filesystem::path const&
+{
+    return dir_;
+}
+
+};  // namespace pisa

--- a/test/test_block_freq_index.cpp
+++ b/test/test_block_freq_index.cpp
@@ -41,7 +41,7 @@ void test_block_freq_index()
         b.add_posting_list(n, plist.first.begin(), plist.second.begin(), 0);
     }
 
-    Temporary_Directory tmpdir;
+    pisa::TemporaryDirectory tmpdir;
     auto filename = (tmpdir.path() / "temp.bin").string();
     {
         collection_type coll;

--- a/test/test_forward_index_builder.cpp
+++ b/test/test_forward_index_builder.cpp
@@ -105,7 +105,7 @@ TEST_CASE("Build forward index batch", "[parsing][forward_index]")
                 "Doc14", "curabitur a justo vitae turpis feugiat molestie eu ac nunc", "")};
         WHEN("write a batch to temp directory")
         {
-            Temporary_Directory tmpdir;
+            pisa::TemporaryDirectory tmpdir;
             auto output_file = tmpdir.path() / "fwd";
             Forward_Index_Builder::Batch_Process bp{
                 7, records, Document_Id{10}, output_file.string()};
@@ -169,7 +169,7 @@ void write_batch(
 
 TEST_CASE("Merge forward index batches", "[parsing][forward_index]")
 {
-    Temporary_Directory tmpdir;
+    pisa::TemporaryDirectory tmpdir;
     auto dir = tmpdir.path();
     GIVEN("Three batches on disk")
     {
@@ -333,7 +333,7 @@ TEST_CASE("Build forward index", "[parsing][forward_index][integration]")
         int batch_size = GENERATE(123, 1000);
         WHEN("Build a forward index")
         {
-            Temporary_Directory tmpdir;
+            pisa::TemporaryDirectory tmpdir;
             auto dir = tmpdir.path();
             std::string output = (dir / "fwd").string();
 

--- a/test/test_freq_index.cpp
+++ b/test/test_freq_index.cpp
@@ -21,7 +21,7 @@
 template <typename DocsSequence, typename FreqsSequence>
 void test_freq_index()
 {
-    Temporary_Directory tmpdir;
+    pisa::TemporaryDirectory tmpdir;
     auto idx_path = (tmpdir.path() / "coll.bin").string();
 
     pisa::global_parameters params;

--- a/test/test_invert.cpp
+++ b/test/test_invert.cpp
@@ -249,7 +249,7 @@ TEST_CASE("Invert collection", "[invert][unit]")
 {
     GIVEN("A binary collection")
     {
-        Temporary_Directory tmpdir;
+        pisa::TemporaryDirectory tmpdir;
         uint32_t batch_size = GENERATE(1, 2, 3, 4, 5);
         uint32_t threads = GENERATE(1, 2, 3, 4, 5);
         invert::InvertParams params;

--- a/test/test_memory_source.cpp
+++ b/test/test_memory_source.cpp
@@ -24,14 +24,14 @@ TEST_CASE("Empty memory source", "[mmap][io]")
 
 TEST_CASE("Error when mapping non-existent file", "[mmap][io]")
 {
-    Temporary_Directory temp;
+    pisa::TemporaryDirectory temp;
     auto file_path = (temp.path() / "file");
     REQUIRE_THROWS_AS(MemorySource::mapped_file(file_path), NoSuchFile);
 }
 
 TEST_CASE("Non-empty memory source", "[mmap][io]")
 {
-    Temporary_Directory temp;
+    pisa::TemporaryDirectory temp;
     auto file_path = (temp.path() / "file");
     {
         std::ofstream os(file_path.string());

--- a/test/test_partition_fwd_index.cpp
+++ b/test/test_partition_fwd_index.cpp
@@ -51,7 +51,7 @@ TEST_CASE("Expand shard", "[sharding]")
 
 TEST_CASE("Resolve shards", "[sharding]")
 {
-    Temporary_Directory dir;
+    pisa::TemporaryDirectory dir;
     SECTION("No suffix")
     {
         for (auto f: std::vector<std::string>{"shard.000", "shard.001", "shard.002"}) {
@@ -153,7 +153,7 @@ TEST_CASE("copy_sequence", "[invert][unit]")
 {
     GIVEN("A test forward index")
     {
-        Temporary_Directory dir;
+        pisa::TemporaryDirectory dir;
         std::string fwd_basename = (dir.path() / "fwd").string();
         std::string output = (dir.path() / "copy").string();
         int document_count = 1'000;
@@ -184,7 +184,7 @@ TEST_CASE("Rearrange sequences", "[invert][integration]")
 {
     GIVEN("A test forward index")
     {
-        Temporary_Directory dir;
+        pisa::TemporaryDirectory dir;
         std::string fwd_basename = (dir.path() / "fwd").string();
         std::string output_basename = (dir.path() / "shards").string();
         int document_count = 1'000;
@@ -240,7 +240,7 @@ TEST_CASE("partition_fwd_index", "[invert][integration]")
 {
     GIVEN("A test forward index")
     {
-        Temporary_Directory dir;
+        pisa::TemporaryDirectory dir;
         std::string fwd_basename = (dir.path() / "fwd").string();
         std::string output_basename = (dir.path() / "shards").string();
         int document_count = 1'000;

--- a/test/test_queries.cpp
+++ b/test/test_queries.cpp
@@ -25,7 +25,7 @@ TEST_CASE("Parse query term ids with query id")
 
 TEST_CASE("Compute parsing function")
 {
-    Temporary_Directory tmpdir;
+    pisa::TemporaryDirectory tmpdir;
 
     auto lexfile = tmpdir.path() / "lex";
     encode_payload_vector(
@@ -78,7 +78,7 @@ TEST_CASE("Compute parsing function")
 
 TEST_CASE("Load stopwords in term processor with all stopwords present in the lexicon")
 {
-    Temporary_Directory tmpdir;
+    pisa::TemporaryDirectory tmpdir;
     auto lexfile = tmpdir.path() / "lex";
     encode_payload_vector(
         gsl::make_span(std::vector<std::string>{"a", "account", "he", "she", "usa", "world"}))
@@ -96,7 +96,7 @@ TEST_CASE("Load stopwords in term processor with all stopwords present in the le
 
 TEST_CASE("Load stopwords in term processor with some stopwords not present in the lexicon")
 {
-    Temporary_Directory tmpdir;
+    pisa::TemporaryDirectory tmpdir;
     auto lexfile = tmpdir.path() / "lex";
     encode_payload_vector(
         gsl::make_span(std::vector<std::string>{"account", "coffee", "he", "she", "usa", "world"}))
@@ -114,7 +114,7 @@ TEST_CASE("Load stopwords in term processor with some stopwords not present in t
 
 TEST_CASE("Check if term is stopword")
 {
-    Temporary_Directory tmpdir;
+    pisa::TemporaryDirectory tmpdir;
     auto lexfile = tmpdir.path() / "lex";
     encode_payload_vector(
         gsl::make_span(std::vector<std::string>{"account", "coffee", "he", "she", "usa", "world"}))

--- a/test/test_recursive_graph_bisection.cpp
+++ b/test/test_recursive_graph_bisection.cpp
@@ -50,7 +50,7 @@ void compare_strcolls(StrColl const& expected, StrColl const& actual)
 
 TEST_CASE("Reorder documents with BP")
 {
-    Temporary_Directory tmp;
+    pisa::TemporaryDirectory tmp;
 
     auto next_record = [](std::istream& in) -> std::optional<Document_Record> {
         Plaintext_Record record;

--- a/test/test_sample_inverted_index.cpp
+++ b/test/test_sample_inverted_index.cpp
@@ -17,7 +17,7 @@ TEST_CASE("sample_inverted_index")
     // given
     using pisa::binary_freq_collection;
     std::string input(PISA_SOURCE_DIR "/test/test_data/test_collection");
-    Temporary_Directory tmpdir;
+    pisa::TemporaryDirectory tmpdir;
     std::string output = tmpdir.path().string();
     auto original = binary_freq_collection(input.c_str());
 
@@ -63,7 +63,7 @@ TEST_CASE("sample_inverted_index_one_sample")
     // given
     using pisa::binary_freq_collection;
     std::string input(PISA_SOURCE_DIR "/test/test_data/test_collection");
-    Temporary_Directory tmpdir;
+    pisa::TemporaryDirectory tmpdir;
     std::string output = tmpdir.path().string();
     auto original = binary_freq_collection(input.c_str());
 
@@ -111,7 +111,7 @@ TEST_CASE("sample_inverted_index_reverse")
     // given
     using pisa::binary_freq_collection;
     std::string input(PISA_SOURCE_DIR "/test/test_data/test_collection");
-    Temporary_Directory tmpdir;
+    pisa::TemporaryDirectory tmpdir;
     std::string output = tmpdir.path().string();
     auto original = binary_freq_collection(input.c_str());
     float rate = 0.1;

--- a/test/test_sequence_collection.cpp
+++ b/test/test_sequence_collection.cpp
@@ -30,7 +30,7 @@ void test_sequence_collection()
         b.add_sequence(seq.begin(), seq.back() + 1, n);
     }
 
-    Temporary_Directory tmpdir;
+    pisa::TemporaryDirectory tmpdir;
     auto filename = tmpdir.path().string() + "temp.bin";
     {
         collection_type coll;

--- a/test/test_stream_builder.cpp
+++ b/test/test_stream_builder.cpp
@@ -22,7 +22,7 @@ TEST_CASE("Stream builder for block index", "[index]")
     using index_type = block_simdbp_index;
 
     binary_freq_collection collection(PISA_SOURCE_DIR "/test/test_data/test_collection");
-    Temporary_Directory tmp;
+    pisa::TemporaryDirectory tmp;
     auto expected_path = tmp.path() / "expected";
     auto actual_path = tmp.path() / "actual";
 

--- a/test/test_taily_stats.cpp
+++ b/test/test_taily_stats.cpp
@@ -75,7 +75,7 @@ TEST_CASE("Extract Taily feature stats", "[taily][unit]")
 {
     GIVEN("Collection")
     {
-        Temporary_Directory tmpdir;
+        pisa::TemporaryDirectory tmpdir;
         write_documents(tmpdir.path() / "coll.docs");
         write_frequencies(tmpdir.path() / "coll.freqs");
         write_sizes(tmpdir.path() / "coll.sizes");
@@ -122,7 +122,7 @@ TEST_CASE("Extract Taily feature stats", "[taily][unit]")
 
 TEST_CASE("Write Taily feature stats", "[taily][unit]")
 {
-    Temporary_Directory tmpdir;
+    pisa::TemporaryDirectory tmpdir;
     auto stats_path = tmpdir.path() / "taily";
     GIVEN("Feature statistics")
     {

--- a/test/test_tokenizer.cpp
+++ b/test/test_tokenizer.cpp
@@ -26,7 +26,7 @@ TEST_CASE("TermTokenizer")
 
 TEST_CASE("Parse query terms to ids")
 {
-    Temporary_Directory tmpdir;
+    pisa::TemporaryDirectory tmpdir;
     auto lexfile = tmpdir.path() / "lex";
     encode_payload_vector(
         gsl::make_span(std::vector<std::string>{"lol", "obama", "term2", "tree", "usa"}))


### PR DESCRIPTION
Temporary_Directory is renamed to TemporaryDirectory and moved inside pisa namespace. Implementations are moved to a separate cpp file.

Fixes #419
