### PR TITLE
Whitespace tokenizer

### DIFF
--- a/include/pisa/query/query_stemmer.hpp
+++ b/include/pisa/query/query_stemmer.hpp
@@ -21,9 +21,9 @@ class QueryStemmer {
         std::stringstream tokenized_query;
         auto [id, raw_query] = split_query_at_colon(query_string);
         std::vector<std::string> stemmed_terms;
-        TermTokenizer tokenizer(raw_query);
-        for (auto term_iter = tokenizer.begin(); term_iter != tokenizer.end(); ++term_iter) {
-            stemmed_terms.push_back(m_stemmer(*term_iter));
+        EnglishTokenizer tokenizer(raw_query);
+        for (auto token: tokenizer) {
+            stemmed_terms.push_back(m_stemmer(token));
         }
         if (id) {
             tokenized_query << *(id) << ":";

--- a/src/bit_vector_builder.cpp
+++ b/src/bit_vector_builder.cpp
@@ -5,7 +5,6 @@
 
 namespace pisa {
 
-
 bit_vector_builder::bit_vector_builder(uint64_t size, bool init) : m_size(size)
 {
     m_bits.resize(detail::words_for(size), init ? std::numeric_limits<std::uint64_t>::max() : 0U);

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -153,7 +153,7 @@ record_parser(std::string const& type, std::istream& is)
 
 void parse_plaintext_content(std::string&& content, std::function<void(std::string&&)> process)
 {
-    TermTokenizer tokenizer(content);
+    EnglishTokenizer tokenizer(content);
     std::for_each(tokenizer.begin(), tokenizer.end(), process);
 }
 
@@ -188,7 +188,7 @@ void parse_html_content(std::string&& content, std::function<void(std::string&&)
     if (content.empty()) {
         return;
     }
-    TermTokenizer tokenizer(content);
+    EnglishTokenizer tokenizer(content);
     std::for_each(tokenizer.begin(), tokenizer.end(), process);
 }
 

--- a/src/query/queries.cpp
+++ b/src/query/queries.cpp
@@ -28,7 +28,7 @@ auto split_query_at_colon(std::string const& query_string)
 auto parse_query_terms(std::string const& query_string, TermProcessor term_processor) -> Query
 {
     auto [id, raw_query] = split_query_at_colon(query_string);
-    TermTokenizer tokenizer(raw_query);
+    EnglishTokenizer tokenizer(raw_query);
     std::vector<term_id_type> parsed_query;
     for (auto term_iter = tokenizer.begin(); term_iter != tokenizer.end(); ++term_iter) {
         auto raw_term = *term_iter;

--- a/src/tokenizer.cpp
+++ b/src/tokenizer.cpp
@@ -1,7 +1,131 @@
 #include "tokenizer.hpp"
 
+#include <cctype>
+#include <string>
+
 namespace pisa {
 
-tokens<lexer_type> const TermTokenizer::LEXER = tokens<lexer_type>{};
+enum TokenType { Abbreviature = 1, Possessive = 2, Term = 3, NotValid = 4 };
+
+TokenizerIterator::TokenizerIterator(Tokenizer* tokenizer) : m_tokenizer(tokenizer), m_pos(0)
+{
+    m_token = m_tokenizer == nullptr ? std::nullopt : m_tokenizer->next();
+}
+
+[[nodiscard]] auto TokenizerIterator::operator*() -> value_type
+{
+    return *m_token;
+}
+
+auto TokenizerIterator::operator++() -> TokenizerIterator&
+{
+    if (m_token.has_value()) {
+        m_token = m_tokenizer->next();
+        ++m_pos;
+    }
+    return *this;
+}
+
+[[nodiscard]] auto TokenizerIterator::operator++(int) -> TokenizerIterator
+{
+    auto copy = *this;
+    ++(*this);
+    return copy;
+}
+
+[[nodiscard]] auto TokenizerIterator::operator==(TokenizerIterator const& other) -> bool
+{
+    if (m_token.has_value() && other.m_token.has_value()) {
+        return m_pos == other.m_pos;
+    }
+    return m_token.has_value() == other.m_token.has_value();
+}
+
+[[nodiscard]] auto TokenizerIterator::operator!=(TokenizerIterator const& other) -> bool
+{
+    return !(*this == other);
+}
+
+auto Tokenizer::begin() -> TokenizerIterator
+{
+    return TokenizerIterator(this);
+}
+
+auto Tokenizer::end() -> TokenizerIterator
+{
+    return TokenizerIterator(nullptr);
+}
+
+[[nodiscard]] auto is_space(char symbol) -> bool
+{
+    return std::isspace(static_cast<unsigned char>(symbol)) != 0;
+}
+
+auto is_valid(token_type const& tok) -> bool
+{
+    return tok.id() != TokenType::NotValid;
+}
+
+WhitespaceTokenizer::WhitespaceTokenizer(std::string_view input) : m_input(input) {}
+
+auto WhitespaceTokenizer::next() -> std::optional<std::string>
+{
+    auto pos = std::find_if_not(m_input.begin(), m_input.end(), is_space);
+    m_input = m_input.substr(std::distance(m_input.begin(), pos));
+    if (m_input.empty()) {
+        return std::nullopt;
+    }
+    pos = std::find_if(m_input.begin(), m_input.end(), is_space);
+    auto token = m_input.substr(0, std::distance(m_input.begin(), pos));
+    m_input = m_input.substr(std::distance(m_input.begin(), pos));
+    return std::string(token);
+}
+
+auto transform_token(token_type const& tok) -> std::string
+{
+    auto& val = tok.value();
+    switch (tok.id()) {
+    case TokenType::Abbreviature: {
+        std::string term;
+        std::copy_if(
+            val.begin(), val.end(), std::back_inserter(term), [](char ch) { return ch != '.'; });
+        return term;
+    }
+    case TokenType::Possessive:
+        return std::string(val.begin(), std::find(val.begin(), val.end(), '\''));
+    default: return std::string(val.begin(), val.end());
+    }
+}
+
+Lexer::Lexer()
+{
+    // Note: parsing process takes the first match from left to right.
+    this->self = lex::token_def<>("([a-zA-Z]+\\.){2,}", TokenType::Abbreviature)
+        | lex::token_def<>("[a-zA-Z0-9]+('[a-zA-Z]+)", TokenType::Possessive)
+        | lex::token_def<>("[a-zA-Z0-9]+", TokenType::Term)
+        | lex::token_def<>(".", TokenType::NotValid);
+}
+
+Lexer const EnglishTokenizer::LEXER = Lexer{};
+
+EnglishTokenizer::EnglishTokenizer(std::string_view input)
+    : m_begin(input.begin()),
+      m_end(input.end()),
+      m_pos(LEXER.begin(m_begin, m_end)),
+      m_sentinel(LEXER.end())
+{}
+
+auto EnglishTokenizer::next() -> std::optional<std::string>
+{
+    while (m_pos != m_sentinel && !is_valid(*m_pos)) {
+        ++m_pos;
+    }
+    if (m_pos == m_sentinel) {
+        return std::nullopt;
+    }
+    auto token = transform_token(*m_pos);
+    ++m_pos;
+    return token;
+}
 
 }  // namespace pisa

--- a/test/test_forward_index_builder.cpp
+++ b/test/test_forward_index_builder.cpp
@@ -370,7 +370,7 @@ TEST_CASE("Build forward index", "[parsing][forward_index][integration]")
                     std::istringstream content_stream(record->content());
                     std::string term;
                     while (content_stream >> term) {
-                        TermTokenizer tok(term);
+                        EnglishTokenizer tok(term);
                         std::for_each(tok.begin(), tok.end(), [&original_body](auto term) {
                             original_body.push_back(std::move(term));
                         });

--- a/test/test_tokenizer.cpp
+++ b/test/test_tokenizer.cpp
@@ -14,14 +14,76 @@
 
 using namespace pisa;
 
-TEST_CASE("TermTokenizer")
+TEST_CASE("WhitespaceTokenizer")
 {
-    std::string str("a 1 12 w0rd, token-izer. pup's, U.S.a., us., hel.lo");
-    TermTokenizer tokenizer(str);
-    REQUIRE(
-        std::vector<std::string>(tokenizer.begin(), tokenizer.end())
-        == std::vector<std::string>{
-            "a", "1", "12", "w0rd", "token", "izer", "pup", "USa", "us", "hel", "lo"});
+    WHEN("Empty input")
+    {
+        std::string input = "";
+        WhitespaceTokenizer tok(input);
+        REQUIRE(tok.next() == std::nullopt);
+    }
+    WHEN("Input with only whitespaces")
+    {
+        std::string input = " \t  ";
+        WhitespaceTokenizer tok(input);
+        REQUIRE(tok.next() == std::nullopt);
+    }
+    WHEN("Input without spaces around")
+    {
+        std::string input = "dog cat";
+        WhitespaceTokenizer tok(input);
+        REQUIRE(tok.next() == "dog");
+        REQUIRE(tok.next() == "cat");
+        REQUIRE(tok.next() == std::nullopt);
+    }
+    WHEN("Input with spaces around")
+    {
+        std::string input = "\tbling ##ing\tsting  ?*I(*&())  ";
+        WhitespaceTokenizer tok(input);
+        REQUIRE(tok.next() == "bling");
+        REQUIRE(tok.next() == "##ing");
+        REQUIRE(tok.next() == "sting");
+        REQUIRE(tok.next() == "?*I(*&())");
+        REQUIRE(tok.next() == std::nullopt);
+    }
+    SECTION("With iterators")
+    {
+        std::string input = "\tbling ##ing\tsting  ?*I(*&())  ";
+        WhitespaceTokenizer tok(input);
+        REQUIRE(
+            std::vector<std::string>(tok.begin(), tok.end())
+            == std::vector<std::string>{"bling", "##ing", "sting", "?*I(*&())"});
+    }
+}
+
+TEST_CASE("EnglishTokenizer")
+{
+    SECTION("With next()")
+    {
+        std::string str("a 1 12 w0rd, token-izer. pup's, U.S.a., us., hel.lo");
+        EnglishTokenizer tok(str);
+        REQUIRE(tok.next() == "a");
+        REQUIRE(tok.next() == "1");
+        REQUIRE(tok.next() == "12");
+        REQUIRE(tok.next() == "w0rd");
+        REQUIRE(tok.next() == "token");
+        REQUIRE(tok.next() == "izer");
+        REQUIRE(tok.next() == "pup");
+        REQUIRE(tok.next() == "USa");
+        REQUIRE(tok.next() == "us");
+        REQUIRE(tok.next() == "hel");
+        REQUIRE(tok.next() == "lo");
+        REQUIRE(tok.next() == std::nullopt);
+    }
+    SECTION("With iterators")
+    {
+        std::string str("a 1 12 w0rd, token-izer. pup's, U.S.a., us., hel.lo");
+        EnglishTokenizer tokenizer(str);
+        REQUIRE(
+            std::vector<std::string>(tokenizer.begin(), tokenizer.end())
+            == std::vector<std::string>{
+                "a", "1", "12", "w0rd", "token", "izer", "pup", "USa", "us", "hel", "lo"});
+    }
 }
 
 TEST_CASE("Parse query terms to ids")


### PR DESCRIPTION
Implements a whitespace tokenizer next to the old term tokenizer. The old tokenizer is renamed to EnglishTokenizer (as it contains English-specific rules such as possessives), and both tokenizers are now organized into a class hierarchy with a common virtual interface, so that they could be used interchangeably in the future, as well so that perhaps more tokenizers can be implemented.

Related to #494
