### PR TITLE
Selecting tokenizer at query time

### DIFF
--- a/include/pisa/query/queries.hpp
+++ b/include/pisa/query/queries.hpp
@@ -8,6 +8,7 @@
 #include <vector>
 
 #include "query/term_processor.hpp"
+#include "tokenizer.hpp"
 
 namespace pisa {
 
@@ -25,13 +26,15 @@ struct Query {
 [[nodiscard]] auto split_query_at_colon(std::string const& query_string)
     -> std::pair<std::optional<std::string>, std::string_view>;
 
-[[nodiscard]] auto parse_query_terms(std::string const& query_string, TermProcessor term_processor)
+[[nodiscard]] auto parse_query_terms(
+    std::string const& query_string, Tokenizer const& tokenizer, TermProcessor term_processor)
     -> Query;
 
 [[nodiscard]] auto parse_query_ids(std::string const& query_string) -> Query;
 
 [[nodiscard]] std::function<void(const std::string)> resolve_query_parser(
     std::vector<Query>& queries,
+    std::unique_ptr<pisa::Tokenizer> tokenizer,
     std::optional<std::string> const& terms_file,
     std::optional<std::string> const& stopwords_filename,
     std::optional<std::string> const& stemmer_type);

--- a/include/pisa/query/query_stemmer.hpp
+++ b/include/pisa/query/query_stemmer.hpp
@@ -21,7 +21,7 @@ class QueryStemmer {
         std::stringstream tokenized_query;
         auto [id, raw_query] = split_query_at_colon(query_string);
         std::vector<std::string> stemmed_terms;
-        EnglishTokenizer tokenizer(raw_query);
+        EnglishTokenStream tokenizer(raw_query);
         for (auto token: tokenizer) {
             stemmed_terms.push_back(m_stemmer(token));
         }

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -153,7 +153,7 @@ record_parser(std::string const& type, std::istream& is)
 
 void parse_plaintext_content(std::string&& content, std::function<void(std::string&&)> process)
 {
-    EnglishTokenizer tokenizer(content);
+    EnglishTokenStream tokenizer(content);
     std::for_each(tokenizer.begin(), tokenizer.end(), process);
 }
 
@@ -188,7 +188,7 @@ void parse_html_content(std::string&& content, std::function<void(std::string&&)
     if (content.empty()) {
         return;
     }
-    EnglishTokenizer tokenizer(content);
+    EnglishTokenStream tokenizer(content);
     std::for_each(tokenizer.begin(), tokenizer.end(), process);
 }
 

--- a/test/test_forward_index_builder.cpp
+++ b/test/test_forward_index_builder.cpp
@@ -370,7 +370,7 @@ TEST_CASE("Build forward index", "[parsing][forward_index][integration]")
                     std::istringstream content_stream(record->content());
                     std::string term;
                     while (content_stream >> term) {
-                        EnglishTokenizer tok(term);
+                        EnglishTokenStream tok(term);
                         std::for_each(tok.begin(), tok.end(), [&original_body](auto term) {
                             original_body.push_back(std::move(term));
                         });

--- a/test/test_tokenizer.cpp
+++ b/test/test_tokenizer.cpp
@@ -19,19 +19,19 @@ TEST_CASE("WhitespaceTokenizer")
     WHEN("Empty input")
     {
         std::string input = "";
-        WhitespaceTokenizer tok(input);
+        WhitespaceTokenStream tok(input);
         REQUIRE(tok.next() == std::nullopt);
     }
     WHEN("Input with only whitespaces")
     {
         std::string input = " \t  ";
-        WhitespaceTokenizer tok(input);
+        WhitespaceTokenStream tok(input);
         REQUIRE(tok.next() == std::nullopt);
     }
     WHEN("Input without spaces around")
     {
         std::string input = "dog cat";
-        WhitespaceTokenizer tok(input);
+        WhitespaceTokenStream tok(input);
         REQUIRE(tok.next() == "dog");
         REQUIRE(tok.next() == "cat");
         REQUIRE(tok.next() == std::nullopt);
@@ -39,7 +39,7 @@ TEST_CASE("WhitespaceTokenizer")
     WHEN("Input with spaces around")
     {
         std::string input = "\tbling ##ing\tsting  ?*I(*&())  ";
-        WhitespaceTokenizer tok(input);
+        WhitespaceTokenStream tok(input);
         REQUIRE(tok.next() == "bling");
         REQUIRE(tok.next() == "##ing");
         REQUIRE(tok.next() == "sting");
@@ -49,7 +49,7 @@ TEST_CASE("WhitespaceTokenizer")
     SECTION("With iterators")
     {
         std::string input = "\tbling ##ing\tsting  ?*I(*&())  ";
-        WhitespaceTokenizer tok(input);
+        WhitespaceTokenStream tok(input);
         REQUIRE(
             std::vector<std::string>(tok.begin(), tok.end())
             == std::vector<std::string>{"bling", "##ing", "sting", "?*I(*&())"});
@@ -61,7 +61,7 @@ TEST_CASE("EnglishTokenizer")
     SECTION("With next()")
     {
         std::string str("a 1 12 w0rd, token-izer. pup's, U.S.a., us., hel.lo");
-        EnglishTokenizer tok(str);
+        EnglishTokenStream tok(str);
         REQUIRE(tok.next() == "a");
         REQUIRE(tok.next() == "1");
         REQUIRE(tok.next() == "12");
@@ -78,7 +78,7 @@ TEST_CASE("EnglishTokenizer")
     SECTION("With iterators")
     {
         std::string str("a 1 12 w0rd, token-izer. pup's, U.S.a., us., hel.lo");
-        EnglishTokenizer tokenizer(str);
+        EnglishTokenStream tokenizer(str);
         REQUIRE(
             std::vector<std::string>(tokenizer.begin(), tokenizer.end())
             == std::vector<std::string>{
@@ -104,7 +104,8 @@ TEST_CASE("Parse query terms to ids")
              {"U.S.A.!?", std::nullopt, {4}}}));
     CAPTURE(query);
     TermProcessor term_processor(std::make_optional(lexfile.string()), std::nullopt, "krovetz");
-    auto q = parse_query_terms(query, term_processor);
+    EnglishTokenizer tokenizer;
+    auto q = parse_query_terms(query, tokenizer, term_processor);
     REQUIRE(q.id == id);
     REQUIRE(q.terms == parsed);
 }


### PR DESCRIPTION
Note that the code around parsing is a bit of a mess generally. I'd like to address that but I want to do this step by step.

For now, I just enhanced the solution we have now for query parsing, so that we can chose between tokenizers. The old English tokenizer is still the default if nothing is defined.

I want to then implement it on the collection parsing side, and only after that I'd like to unify it a little by introducing some kind of parsing "pipeline". I don't have the details nailed down yet, I'll share them when I get a chance to think about it. 