### PR TITLE
Custom sift down for binary heap

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -70,3 +70,6 @@
 [submodule "external/taily"]
 	path = external/taily
 	url = https://github.com/pisa-engine/taily.git
+[submodule "external/benchmark"]
+	path = external/benchmark
+	url = https://github.com/google/benchmark.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,9 @@ option(PISA_ENABLE_BENCHMARKING "Enable benchmarking of the library." ON)
 option(PISA_ENABLE_CLANG_TIDY "Enable static analysis with clang-tidy" OFF)
 option(PISA_CLANG_TIDY_EXECUTABLE "clang-tidy executable path" "clang-tidy")
 option(PISA_USE_PIC "Enable Position-Independent code globally" ON)
-option(PISA_CI_BUILD "Remove debug information from Debug build" ON)
+option(PISA_CI_BUILD "Remove debug information from Debug build" OFF)
+
+option(PISA_SYSTEM_GOOGLE_BENCHMARK "Use system installation of Google benchmark library" ON)
 
 if(PISA_USE_PIC)
     set(CMAKE_POSITION_INDEPENDENT_CODE ON)
@@ -149,7 +151,8 @@ if (PISA_BUILD_TOOLS)
 endif()
 
 if (PISA_ENABLE_BENCHMARKING)
-  add_subdirectory(benchmarks)
+    add_subdirectory(microbench)
+    add_subdirectory(benchmarks)
 endif()
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ option(PISA_CLANG_TIDY_EXECUTABLE "clang-tidy executable path" "clang-tidy")
 option(PISA_USE_PIC "Enable Position-Independent code globally" ON)
 option(PISA_CI_BUILD "Remove debug information from Debug build" OFF)
 
-option(PISA_SYSTEM_GOOGLE_BENCHMARK "Use system installation of Google benchmark library" ON)
+option(PISA_SYSTEM_GOOGLE_BENCHMARK "Use system installation of Google benchmark library" OFF)
 
 if(PISA_USE_PIC)
     set(CMAKE_POSITION_INDEPENDENT_CODE ON)

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -99,3 +99,8 @@ set(TAILY_ENABLE_TESTING OFF CACHE BOOL "skip taily testing")
 set(TAILY_BUILD_EXAMPLE OFF CACHE BOOL "skip taily example")
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/taily)
 target_compile_options(taily INTERFACE -Wno-unused-variable)
+
+if (PISA_ENABLE_TESTING AND NOT PISA_SYSTEM_GOOGLE_BENCHMARK)
+    add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/benchmark)
+    target_compile_options(benchmark::benchmark PRIVATE -Wno-error=all -Wno-unused-but-set-variable)
+endif()

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -101,6 +101,7 @@ add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/taily)
 target_compile_options(taily INTERFACE -Wno-unused-variable)
 
 if (PISA_ENABLE_TESTING AND NOT PISA_SYSTEM_GOOGLE_BENCHMARK)
+    set(BENCHMARK_ENABLE_GTEST_TESTS OFF CACHE BOOL "skip Google Benchmark testing")
     add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/benchmark)
-    target_compile_options(benchmark::benchmark PRIVATE -Wno-error=all -Wno-unused-but-set-variable)
+    target_compile_options(benchmark PRIVATE -Wno-error=all -Wno-unused-but-set-variable)
 endif()

--- a/microbench/CMakeLists.txt
+++ b/microbench/CMakeLists.txt
@@ -1,0 +1,6 @@
+if (PISA_SYSTEM_GOOGLE_BENCHMARK)
+    find_package(benchmark REQUIRED)
+endif()
+
+add_executable(topk_queue_bench topk_queue_bench.cpp)
+target_link_libraries(topk_queue_bench pisa benchmark::benchmark)

--- a/microbench/topk_queue_bench.cpp
+++ b/microbench/topk_queue_bench.cpp
@@ -1,0 +1,91 @@
+#include <algorithm>
+#include <random>
+#include <string>
+
+#include <benchmark/benchmark.h>
+
+#include <pisa/topk_queue.hpp>
+
+using Entry = std::pair<float, std::uint32_t>;
+
+enum Series : std::int64_t {
+    INCREASING = 0,
+    DECREASING = 1,
+    RANDOM = 2,
+};
+
+auto generate_increasing_scores(std::size_t length)
+{
+    std::vector<Entry> vals;
+    std::generate_n(std::back_inserter(vals), length, [score = 100.0, docid = 0]() mutable {
+        score += 0.1;
+        return Entry{score, docid++};
+    });
+    return vals;
+}
+
+auto generate_decreasing_scores(std::size_t length)
+{
+    std::vector<Entry> vals;
+    std::generate_n(std::back_inserter(vals), length, [score = 100.0, docid = 0]() mutable {
+        score -= 0.1;
+        return Entry{score, docid++};
+    });
+    return vals;
+}
+
+auto generate_random_scores(std::size_t length)
+{
+    std::mt19937 gen(1902741074);
+    std::uniform_real_distribution<> dis(0.0, 10.0);
+    std::vector<Entry> vals;
+    std::generate_n(std::back_inserter(vals), length, [&, docid = 0]() mutable {
+        return Entry{dis(gen), docid++};
+    });
+    return vals;
+}
+
+auto generate_entries(std::size_t length, Series series)
+{
+    switch (series) {
+    case INCREASING: return generate_increasing_scores(length);
+    case DECREASING: return generate_decreasing_scores(length);
+    case RANDOM: return generate_random_scores(length);
+    }
+    throw std::logic_error("unreachable");
+}
+
+void insert_all(pisa::topk_queue& queue, std::vector<Entry> const& entries)
+{
+    for (auto const& [score, docid]: entries) {
+        benchmark::DoNotOptimize(queue.insert(score, docid));
+    }
+}
+
+static void bm_topk_queue(benchmark::State& state)
+{
+    auto entries = generate_entries(state.range(0), Series{state.range(2)});
+    for (auto _: state) {
+        pisa::topk_queue queue(state.range(1));
+
+        auto start = std::chrono::high_resolution_clock::now();
+
+        benchmark::DoNotOptimize(queue.topk().data());
+        insert_all(queue, entries);
+
+        auto end = std::chrono::high_resolution_clock::now();
+        auto elapsed_seconds = std::chrono::duration_cast<std::chrono::duration<double>>(end - start);
+
+        state.SetIterationTime(elapsed_seconds.count());
+        benchmark::ClobberMemory();
+    }
+}
+
+BENCHMARK(bm_topk_queue)
+    ->ArgNames({"len", "k", "series"})
+    ->ArgsProduct({{1'000'000}, {10}, {INCREASING, DECREASING, RANDOM}})
+    ->Unit(benchmark::kMicrosecond)
+    ->Repetitions(20)
+    ->DisplayAggregatesOnly();
+
+BENCHMARK_MAIN();


### PR DESCRIPTION
Fixes #504

The previous solution where we swap first and last elements of the heap
and call `pop_heap` is incorrect according to the standard, and fails
when compiled with libc++ 15. Calling `push_heap` in addition to
`pop_heap` is less efficient; in fact, the custom sift down solution is
more efficient than the previous implementation (according to the
microbenchmarks).
