### PR TITLE
Rank start from 1 instead of 0

### DIFF
--- a/tools/evaluate_queries.cpp
+++ b/tools/evaluate_queries.cpp
@@ -155,7 +155,7 @@ void evaluate_queries(
                 qid.value_or(std::to_string(query_idx)),
                 iteration,
                 docmap[result.second],
-                rank,
+                rank + 1,
                 result.first,
                 run_id);
         }


### PR DESCRIPTION
Rank in TREC files should start from 1. This is probably not very important when evaluating with `trec_eval`, but it is crucial when the TREC file is converted to a TSV file for `msmarco_passage_eval.py`
