### PR TITLE
Pass last_level by value

### DIFF
--- a/include/pisa/recursive_graph_bisection.hpp
+++ b/include/pisa/recursive_graph_bisection.hpp
@@ -342,7 +342,7 @@ void recursive_graph_bisection(std::vector<computation_node<Iterator>> nodes, pr
         bool last_level = last == end;
         tbb::task_group level_group;
         std::for_each(first, last, [&thread_local_data, &level_group, last_level, &p](auto& node) {
-            level_group.run([&]() {
+            level_group.run([&, last_level]() {
                 std::sort(node.partition.left.begin(), node.partition.left.end());
                 std::sort(node.partition.right.begin(), node.partition.right.end());
                 if (node.cache) {


### PR DESCRIPTION
In network BP algorithm, `last_level` was passed by value to one lambda, but by reference in the inner lambda, which meant it was dropped before it was used. Passing it by value both times fixes the issue.

Fixes #525