### PR TITLE
Update test Docker images for Clang

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -35,3 +35,4 @@ docs/**/*.pdf
 .github
 
 Dockerfile
+test/**/Dockerfile

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -9,12 +9,12 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        compiler: [gcc9, gcc10, gcc11, gcc12, clang11, clang12]
+        compiler: [gcc9, gcc10, gcc11, gcc12, clang12, clang15]
         standard: [17]
         include:
           - compiler: gcc12 # Extra test for C++20
             standard: 20
-          - compiler: clang12 # Extra test for C++20
+          - compiler: clang15 # Extra test for C++20
             standard: 20
 
     steps:

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -11,11 +11,13 @@ jobs:
       matrix:
         compiler: [gcc9, gcc10, gcc11, gcc12, clang12, clang15]
         standard: [17]
+        sanitizers: [OFF]
         include:
-          - compiler: gcc12 # Extra test for C++20
+          - compiler: gcc12   # Extra test for C++20
             standard: 20
           - compiler: clang15 # Extra test for C++20
             standard: 20
+            sanitizers: ON    # Also run with sanitizers
 
     steps:
     - uses: actions/checkout@v2
@@ -25,7 +27,9 @@ jobs:
     - name: Bulid docker image
       shell: bash
       run: |
-        docker build --build-arg CXX_STANDARD=${{matrix.standard}} \
+        docker build \
+          --build-arg CXX_STANDARD=${{matrix.standard}} \
+          --build-arg USE_SANITIZERS=${{matrix.sanitizers}} \
           -t pisa -f- . < "${{runner.workspace}}/pisa/test/docker/${{matrix.compiler}}/Dockerfile"
 
     - name: Test

--- a/test/docker/clang11/Dockerfile
+++ b/test/docker/clang11/Dockerfile
@@ -1,23 +1,18 @@
-FROM silkeh/clang:11
+FROM debian:bullseye
 
-ENV TOOLCHAIN="-DCMAKE_TOOLCHAIN_FILE=clang.cmake"
-ENV DEBIAN_FRONTEND=noninteractive
-ENV TZ=America/New_York
-
-RUN apt-get update -y && apt-get install -y --no-install-recommends \
-    cmake=3.18.* \
-    libtool=2.4.* \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
+ARG CXX_STANDARD=17
+ARG DEBIAN_FRONTEND=noninteractive
 
 COPY . /pisa
+RUN ./pisa/test/docker/install-clang.sh 11
+
 RUN mkdir /pisa/build
 WORKDIR /pisa/build
+
 RUN cmake \
     -DCMAKE_BUILD_TYPE='Debug' \
     -DPISA_BUILD_TOOLS='OFF' \
     -DPISA_ENABLE_BENCHMARKING='OFF' \
-    -DCMAKE_TOOLCHAIN_FILE='clang.cmake' \
     .. \
     && cmake --build . --config Debug -- -j 4
 

--- a/test/docker/clang12/Dockerfile
+++ b/test/docker/clang12/Dockerfile
@@ -1,25 +1,21 @@
-FROM silkeh/clang:12
+FROM debian:bullseye
 
 ARG CXX_STANDARD=17
+ARG DEBIAN_FRONTEND=noninteractive
 
-ENV TOOLCHAIN="-DCMAKE_TOOLCHAIN_FILE=clang.cmake"
-ENV DEBIAN_FRONTEND=noninteractive
-ENV TZ=America/New_York
-
-RUN apt-get update -y && apt-get install -y --no-install-recommends \
-    cmake=3.18.* \
-    libtool=2.4.* \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
+COPY /test/docker/install-clang.sh /
+RUN /install-clang.sh 12
 
 COPY . /pisa
 RUN mkdir /pisa/build
 WORKDIR /pisa/build
+
 RUN cmake \
     -DCMAKE_BUILD_TYPE='Debug' \
     -DPISA_BUILD_TOOLS='OFF' \
     -DPISA_ENABLE_BENCHMARKING='OFF' \
     -DCMAKE_TOOLCHAIN_FILE='clang.cmake' \
+    "-DCMAKE_CXX_STANDARD=$CXX_STANDARD" \
     .. \
     && cmake --build . --config Debug -- -j 4
 

--- a/test/docker/clang12/Dockerfile
+++ b/test/docker/clang12/Dockerfile
@@ -1,6 +1,7 @@
 FROM debian:bullseye
 
 ARG CXX_STANDARD=17
+ARG USE_SANITIZERS=OFF
 ARG DEBIAN_FRONTEND=noninteractive
 
 COPY /test/docker/install-clang.sh /
@@ -15,6 +16,7 @@ RUN cmake \
     -DPISA_BUILD_TOOLS='OFF' \
     -DPISA_ENABLE_BENCHMARKING='OFF' \
     -DCMAKE_TOOLCHAIN_FILE='clang.cmake' \
+    "-DUSE_SANITIZERS=$USE_SANITIZERS" \
     "-DCMAKE_CXX_STANDARD=$CXX_STANDARD" \
     .. \
     && cmake --build . --config Debug -- -j 4

--- a/test/docker/clang15/Dockerfile
+++ b/test/docker/clang15/Dockerfile
@@ -1,22 +1,22 @@
-FROM silkeh/clang:15-bullseye
+FROM debian:bullseye
 
-ENV TOOLCHAIN="-DCMAKE_TOOLCHAIN_FILE=clang.cmake"
-ENV DEBIAN_FRONTEND=noninteractive
-ENV TZ=America/New_York
+ARG CXX_STANDARD=17
+ARG DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update -y && apt-get install -y --no-install-recommends \
-    cmake=3.18.* \
-    libtool=2.4.* \
-    libc++-15-dev=1:15.* \
-    libc++abi-15-dev=1:15.* \
-    git=1:2.* \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
+COPY /test/docker/install-clang.sh /
+RUN /install-clang.sh 15
 
 COPY . /pisa
 RUN mkdir /pisa/build
 WORKDIR /pisa/build
-RUN cmake -DCMAKE_BUILD_TYPE='Debug' -DPISA_BUILD_TOOLS='OFF' -DCMAKE_TOOLCHAIN_FILE='clang.cmake' .. \
+
+RUN cmake \
+    -DCMAKE_BUILD_TYPE='Debug' \
+    -DPISA_BUILD_TOOLS='OFF' \
+    -DPISA_ENABLE_BENCHMARKING='OFF' \
+    -DCMAKE_TOOLCHAIN_FILE='clang.cmake' \
+    "-DCMAKE_CXX_STANDARD=$CXX_STANDARD" \
+    .. \
     && cmake --build . --config Debug -- -j 4
 
 CMD ["ctest", "-VV", "-j", "4"]

--- a/test/docker/clang15/Dockerfile
+++ b/test/docker/clang15/Dockerfile
@@ -1,6 +1,7 @@
 FROM debian:bullseye
 
 ARG CXX_STANDARD=17
+ARG USE_SANITIZERS=OFF
 ARG DEBIAN_FRONTEND=noninteractive
 
 COPY /test/docker/install-clang.sh /
@@ -15,6 +16,7 @@ RUN cmake \
     -DPISA_BUILD_TOOLS='OFF' \
     -DPISA_ENABLE_BENCHMARKING='OFF' \
     -DCMAKE_TOOLCHAIN_FILE='clang.cmake' \
+    "-DUSE_SANITIZERS=$USE_SANITIZERS" \
     "-DCMAKE_CXX_STANDARD=$CXX_STANDARD" \
     .. \
     && cmake --build . --config Debug -- -j 4

--- a/test/docker/gcc10/Dockerfile
+++ b/test/docker/gcc10/Dockerfile
@@ -1,5 +1,8 @@
 FROM gcc:10
 
+ARG CXX_STANDARD=17
+ARG USE_SANITIZERS=OFF
+
 ENV DEBIAN_FRONTEND=noninteractive
 ENV TZ=America/New_York
 
@@ -12,6 +15,8 @@ RUN cmake \
     "-DCMAKE_BUILD_TYPE=Debug" \
     "-DPISA_BUILD_TOOLS=OFF" \
     "-DPISA_ENABLE_BENCHMARKING=OFF" \
+    "-DUSE_SANITIZERS=$USE_SANITIZERS" \
+    "-DCMAKE_CXX_STANDARD=$CXX_STANDARD" \
     .. \
     && cmake --build . --config Debug -- -j 4
 

--- a/test/docker/gcc11/Dockerfile
+++ b/test/docker/gcc11/Dockerfile
@@ -1,5 +1,8 @@
 FROM gcc:11
 
+ARG CXX_STANDARD=17
+ARG USE_SANITIZERS=OFF
+
 ENV DEBIAN_FRONTEND=noninteractive
 ENV TZ=America/New_York
 
@@ -12,6 +15,8 @@ RUN cmake \
     "-DCMAKE_BUILD_TYPE=Debug" \
     "-DPISA_BUILD_TOOLS=OFF" \
     "-DPISA_ENABLE_BENCHMARKING=OFF" \
+    "-DUSE_SANITIZERS=$USE_SANITIZERS" \
+    "-DCMAKE_CXX_STANDARD=$CXX_STANDARD" \
     .. \
     && cmake --build . --config Debug -- -j 4
 

--- a/test/docker/gcc12/Dockerfile
+++ b/test/docker/gcc12/Dockerfile
@@ -1,6 +1,7 @@
 FROM gcc:12
 
 ARG CXX_STANDARD=17
+ARG USE_SANITIZERS=OFF
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV TZ=America/New_York
@@ -14,6 +15,7 @@ RUN cmake \
     "-DCMAKE_BUILD_TYPE=Debug" \
     "-DPISA_BUILD_TOOLS=OFF" \
     "-DPISA_ENABLE_BENCHMARKING=OFF" \
+    "-DUSE_SANITIZERS=$USE_SANITIZERS" \
     "-DCMAKE_CXX_STANDARD=$CXX_STANDARD" \
     .. \
     && cmake --build . --config Debug -- -j 4

--- a/test/docker/gcc9/Dockerfile
+++ b/test/docker/gcc9/Dockerfile
@@ -1,5 +1,8 @@
 FROM gcc:9
 
+ARG CXX_STANDARD=17
+ARG USE_SANITIZERS=OFF
+
 ENV DEBIAN_FRONTEND=noninteractive
 ENV TZ=America/New_York
 
@@ -12,6 +15,8 @@ RUN cmake \
     "-DCMAKE_BUILD_TYPE=Debug" \
     "-DPISA_BUILD_TOOLS=OFF" \
     "-DPISA_ENABLE_BENCHMARKING=OFF" \
+    "-DUSE_SANITIZERS=$USE_SANITIZERS" \
+    "-DCMAKE_CXX_STANDARD=$CXX_STANDARD" \
     .. \
     && cmake --build . --config Debug -- -j 4
 

--- a/test/docker/install-clang.sh
+++ b/test/docker/install-clang.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+set -e
+
+[[ -z "$1" ]] && {
+    echo 'usage: install-clang.sh <clang-version>' 1>&2
+    exit 1
+}
+
+version="$1"
+shift
+sources_file='/etc/apt/sources.list.d/llvm.list'
+
+echo 'deb http://apt.llvm.org/bullseye/ llvm-toolchain-bullseye main' > "$sources_file"
+echo 'deb-src http://apt.llvm.org/bullseye/ llvm-toolchain-bullseye main' >> "$sources_file"
+echo "deb http://apt.llvm.org/bullseye/ llvm-toolchain-bullseye-$version main" >> "$sources_file"
+echo "deb-src http://apt.llvm.org/bullseye/ llvm-toolchain-bullseye-$version main" >> "$sources_file"
+
+apt-get update
+apt-get -y install wget sudo gnupg cmake libtool git
+wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+apt-get update
+apt-get -y install \
+    "clang-$version" \
+    "lldb-$version" \
+    "lld-$version" \
+    "libc++-$version-dev" \
+    "libc++abi-$version-dev" \
+    "libunwind-$version-dev" "$@"
+apt-get clean
+rm -rf /var/lib/apt/lists/*
+
+# find "/usr/lib/llvm-$version/" -type f
+for f in /usr/lib/llvm-$version/bin/*
+do
+    ln -sf "$f" /usr/bin
+done

--- a/test/docker/tidy/Dockerfile
+++ b/test/docker/tidy/Dockerfile
@@ -1,19 +1,14 @@
-FROM silkeh/clang:11
+FROM debian:bullseye
 
-ENV TOOLCHAIN="-DCMAKE_TOOLCHAIN_FILE=clang.cmake"
-ENV DEBIAN_FRONTEND=noninteractive
-ENV TZ=America/New_York
+ARG DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update -y && apt-get install -y --no-install-recommends \
-    cmake=3.18.* \
-    libtool=2.4.* \
-    clang-tidy=1:11.* \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
+COPY /test/docker/install-clang.sh /
+RUN /install-clang.sh 15 clang-tidy-15
 
 COPY . /pisa
 RUN mkdir /pisa/build
 WORKDIR /pisa/build
+
 RUN cmake -DCMAKE_BUILD_TYPE=Debug -DPISA_BUILD_TOOLS=ON -DPISA_CLANG_TIDY_EXECUTABLE='clang-tidy' \
     -DPISA_ENABLE_CLANG_TIDY=ON -DCMAKE_TOOLCHAIN_FILE=clang.cmake .. \
     && cmake --build . --config Debug -- -j 3


### PR DESCRIPTION
Using debian:bullseye for base, and installing clang manually, to have more control over it.

Also removing Clang 11 and adding Clang 15 build.