### PR TITLE
Use rapidcheck to test codecs

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        compiler: [gcc12, clang12]
+        compiler: [gcc12, clang15]
         standard: [17]
         include:
           - compiler: gcc12 # Extra test for C++20

--- a/include/pisa/memory.hpp
+++ b/include/pisa/memory.hpp
@@ -36,7 +36,7 @@ class ReinterpretProxy {
 
     [[nodiscard]] auto operator*() const -> T
     {
-        T dst;
+        T dst{0};
         std::memcpy(&dst, m_ptr, m_len);
         return dst;
     }


### PR DESCRIPTION
Rapidcheck makes failures reproducible, as opposed to what we had, which was using `rand` to generate some values.