### PR TITLE
Allow for system Boost installation

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        compiler: [gcc13, clang15]
+        compiler: [gcc13, clang16]
         standard: [17]
         include:
           - compiler: gcc13 # Extra test for C++20

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        compiler: [gcc9, gcc10, gcc11, gcc12, gcc13, clang15, clang16]
+        compiler: [gcc10, gcc11, gcc12, gcc13, clang15, clang16]
         standard: [17]
         sanitizers: [OFF]
         include:

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -9,13 +9,13 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        compiler: [gcc9, gcc10, gcc11, gcc12, gcc13, clang12, clang15]
+        compiler: [gcc9, gcc10, gcc11, gcc12, gcc13, clang15, clang16]
         standard: [17]
         sanitizers: [OFF]
         include:
           - compiler: gcc13   # Extra test for C++20
             standard: 20
-          - compiler: clang15 # Extra test for C++20
+          - compiler: clang16 # Extra test for C++20
             standard: 20
             sanitizers: ON    # Also run with sanitizers
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,7 +115,6 @@ target_link_libraries(pisa
         mio
         mio_base
         GSL
-        Boost::filesystem
         spdlog
         fmt::fmt
         range-v3
@@ -158,7 +157,7 @@ if (PISA_ENABLE_BENCHMARKING)
 endif()
 
 if (PISA_SYSTEM_BOOST)
-    find_package(Boost REQUIRED COMPONENTS filesystem)
+    find_package(Boost REQUIRED)
 endif()
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,7 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 if(NOT CMAKE_CXX_STANDARD EQUAL 17)
     add_compile_definitions(PISA_ENABLE_CONCEPTS=1)
 endif()
+add_compile_definitions(BOOST_NO_CXX98_FUNCTION_BASE=1)
 
 option(PISA_BUILD_TOOLS "Build command line tools." ON)
 option(PISA_ENABLE_TESTING "Enable testing of the library." ON)
@@ -23,6 +24,7 @@ option(PISA_CI_BUILD "Remove debug information from Debug build" OFF)
 
 option(PISA_SYSTEM_GOOGLE_BENCHMARK "Use system installation of Google benchmark library" OFF)
 option(PISA_SYSTEM_ONETBB "Use system installation of oneTBB" OFF)
+option(PISA_SYSTEM_BOOST "Use system installation of Boost" OFF)
 
 if(PISA_USE_PIC)
     set(CMAKE_POSITION_INDEPENDENT_CODE ON)
@@ -153,6 +155,10 @@ endif()
 if (PISA_ENABLE_BENCHMARKING)
     add_subdirectory(microbench)
     add_subdirectory(benchmarks)
+endif()
+
+if (PISA_SYSTEM_BOOST)
+    find_package(Boost REQUIRED COMPONENTS filesystem)
 endif()
 
 

--- a/docs/source/getting_started.md
+++ b/docs/source/getting_started.md
@@ -8,8 +8,8 @@ To compile PISA, you will need a compiler supporting at least the C++17
 standard. Our continuous integration pipeline compiles PISA and runs
 tests in the following configurations:
 - Linux:
-    - GCC, versions: 9, 10, 11, 12
-    - Clang 11
+    - GCC, versions: 10, 11, 12, 13
+    - Clang 15, 16
 - MaxOS:
     - XCode 13.2
 

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -49,9 +49,11 @@ add_library(simdcomp STATIC ${CMAKE_CURRENT_SOURCE_DIR}/simdcomp/src/simdbitpack
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/GSL EXCLUDE_FROM_ALL)
 
 # Add Boost
-add_subdirectory(boost-cmake)
-set(BOOST_INCLUDEDIR ${CMAKE_CURRENT_SOURCE_DIR}/boost-cmake CACHE PATH "Change boost lookup path")
-set(BOOST_LIBRARYDIR ${CMAKE_BINARY_DIR}/boost-cmake CACHE PATH "Change boost lookup path")
+if (NOT PISA_SYSTEM_BOOST)
+    add_subdirectory(boost-cmake)
+    set(BOOST_INCLUDEDIR ${CMAKE_CURRENT_SOURCE_DIR}/boost-cmake CACHE PATH "Change boost lookup path")
+    set(BOOST_LIBRARYDIR ${CMAKE_BINARY_DIR}/boost-cmake CACHE PATH "Change boost lookup path")
+endif()
 
 # Add Catch
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/Catch2)

--- a/include/pisa/cursor/block_max_scored_cursor.hpp
+++ b/include/pisa/cursor/block_max_scored_cursor.hpp
@@ -64,7 +64,7 @@ template <typename Index, typename WandType, typename Scorer>
                 term_weight = term.second;
                 max_weight = term_weight * max_weight;
                 return BlockMaxScoredCursor<typename Index::document_enumerator, WandType>(
-                    std::move(index[term_id]),
+                    index[term_id],
                     [scorer = scorer.term_scorer(term_id), weight = term_weight](
                         uint32_t doc, uint32_t freq) { return weight * scorer(doc, freq); },
                     term_weight,
@@ -73,7 +73,7 @@ template <typename Index, typename WandType, typename Scorer>
             }
 
             return BlockMaxScoredCursor<typename Index::document_enumerator, WandType>(
-                std::move(index[term_id]),
+                index[term_id],
                 scorer.term_scorer(term_id),
                 term_weight,
                 max_weight,

--- a/include/pisa/filesystem.hpp
+++ b/include/pisa/filesystem.hpp
@@ -1,14 +1,17 @@
 #pragma once
 
-#include "boost/filesystem.hpp"
+#include <filesystem>
+#include <functional>
+#include <string>
+#include <vector>
 
 namespace pisa {
 
-[[nodiscard]] auto ls(boost::filesystem::path dir, std::function<bool(std::string const&)> predicate)
+[[nodiscard]] auto ls(std::filesystem::path dir, std::function<bool(std::string const&)> predicate)
 {
-    std::vector<boost::filesystem::path> files;
-    for (auto it = boost::filesystem::directory_iterator(dir);
-         it != boost::filesystem::directory_iterator{};
+    std::vector<std::filesystem::path> files;
+    for (auto it = std::filesystem::directory_iterator(dir);
+         it != std::filesystem::directory_iterator{};
          ++it) {
         if (predicate(it->path().string())) {
             files.push_back(*it);

--- a/include/pisa/forward_index_builder.hpp
+++ b/include/pisa/forward_index_builder.hpp
@@ -6,8 +6,6 @@
 #include <string>
 #include <unordered_map>
 
-#include <boost/filesystem.hpp>
-
 #include "document_record.hpp"
 #include "forward_index_builder.hpp"
 #include "query/term_processor.hpp"

--- a/include/pisa/io.hpp
+++ b/include/pisa/io.hpp
@@ -1,10 +1,11 @@
 #pragma once
 
 #include <exception>
+#include <filesystem>
 #include <iostream>
 #include <string>
+#include <vector>
 
-#include <boost/filesystem.hpp>
 #include <gsl/span>
 
 namespace pisa::io {
@@ -23,7 +24,7 @@ class NoSuchFile: public std::exception {
 };
 
 /// Resolves string as a path; throws NoSuchFile if the file does not exist.
-[[nodiscard]] auto resolve_path(std::string const& file) -> boost::filesystem::path;
+[[nodiscard]] auto resolve_path(std::string const& file) -> std::filesystem::path;
 
 class Line: public std::string {
     friend std::istream& operator>>(std::istream& is, Line& line) { return std::getline(is, line); }

--- a/include/pisa/memory_source.hpp
+++ b/include/pisa/memory_source.hpp
@@ -1,8 +1,9 @@
 #pragma once
 
+#include <filesystem>
 #include <memory>
+#include <vector>
 
-#include <boost/filesystem/path.hpp>
 #include <gsl/span>
 #include <mio/mmap.hpp>
 
@@ -40,7 +41,7 @@ class MemorySource {
     ///
     /// \throws NoSuchFile          if the file doesn't exist
     /// \throws std::system_error   if fails to map the file.
-    [[nodiscard]] static auto mapped_file(boost::filesystem::path file) -> MemorySource;
+    [[nodiscard]] static auto mapped_file(std::filesystem::path file) -> MemorySource;
 
     /// Checks if memory is mapped.
     [[nodiscard]] auto is_mapped() noexcept -> bool;

--- a/include/pisa/payload_vector.hpp
+++ b/include/pisa/payload_vector.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <filesystem>
 #include <fstream>
 #include <iostream>
 #include <iterator>
@@ -7,7 +8,6 @@
 #include <string_view>
 #include <vector>
 
-#include <boost/filesystem.hpp>
 #include <fmt/format.h>
 #include <gsl/gsl_assert>
 #include <gsl/span>
@@ -52,8 +52,9 @@ namespace detail {
 
         [[nodiscard]] constexpr auto operator+(size_type n) const -> Payload_Vector_Iterator
         {
-            return {std::next(offset_iter, n),
-                    std::next(payload_iter, *std::next(offset_iter, n) - *offset_iter)};
+            return {
+                std::next(offset_iter, n),
+                std::next(payload_iter, *std::next(offset_iter, n) - *offset_iter)};
         }
 
         [[nodiscard]] constexpr auto operator+=(size_type n) -> Payload_Vector_Iterator&
@@ -65,8 +66,9 @@ namespace detail {
 
         [[nodiscard]] constexpr auto operator-(size_type n) const -> Payload_Vector_Iterator
         {
-            return {std::prev(offset_iter, n),
-                    std::prev(payload_iter, *offset_iter - *std::prev(offset_iter, n))};
+            return {
+                std::prev(offset_iter, n),
+                std::prev(payload_iter, *offset_iter - *std::prev(offset_iter, n))};
         }
 
         [[nodiscard]] constexpr auto operator-=(size_type n) -> Payload_Vector_Iterator&
@@ -150,8 +152,8 @@ struct Payload_Vector_Buffer {
 
     [[nodiscard]] static auto from_file(std::string const& filename) -> Payload_Vector_Buffer
     {
-        boost::system::error_code ec;
-        auto file_size = boost::filesystem::file_size(boost::filesystem::path(filename));
+        std::error_code ec;
+        auto file_size = std::filesystem::file_size(std::filesystem::path(filename));
         std::ifstream is(filename);
 
         size_type len;

--- a/include/pisa/query/algorithm/block_max_maxscore_query.hpp
+++ b/include/pisa/query/algorithm/block_max_maxscore_query.hpp
@@ -1,8 +1,9 @@
 #pragma once
 
+#include <vector>
+
 #include "query/queries.hpp"
 #include "topk_queue.hpp"
-#include <vector>
 
 namespace pisa {
 

--- a/include/pisa/temporary_directory.hpp
+++ b/include/pisa/temporary_directory.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <boost/filesystem.hpp>
+#include <filesystem>
 
 namespace pisa {
 
@@ -16,10 +16,10 @@ struct TemporaryDirectory {
     ~TemporaryDirectory();
 
     /** Returns the path to the created directory. */
-    [[nodiscard]] auto path() -> boost::filesystem::path const&;
+    [[nodiscard]] auto path() -> std::filesystem::path const&;
 
   private:
-    boost::filesystem::path dir_;
+    std::filesystem::path dir_;
 };
 
 };  // namespace pisa

--- a/include/pisa/util/index_build_utils.hpp
+++ b/include/pisa/util/index_build_utils.hpp
@@ -2,7 +2,6 @@
 
 #include "spdlog/spdlog.h"
 
-#include "boost/filesystem.hpp"
 #include "gsl/span"
 #include "index_types.hpp"
 #include "mappable/mapper.hpp"

--- a/include/pisa/util/inverted_index_utils.hpp
+++ b/include/pisa/util/inverted_index_utils.hpp
@@ -1,8 +1,9 @@
 #pragma once
 
+#include <filesystem>
+#include <fstream>
 #include <unordered_set>
 
-#include <boost/filesystem.hpp>
 #include <gsl/span>
 
 #include "binary_freq_collection.hpp"
@@ -39,10 +40,10 @@ void sample_inverted_index(
 {
     binary_freq_collection input(input_basename.c_str());
 
-    boost::filesystem::copy_file(
+    std::filesystem::copy_file(
         fmt::format("{}.sizes", input_basename),
         fmt::format("{}.sizes", output_basename),
-        boost::filesystem::copy_option::overwrite_if_exists);
+        std::filesystem::copy_options::overwrite_existing);
 
     std::ofstream dos(output_basename + ".docs");
     std::ofstream fos(output_basename + ".freqs");

--- a/include/pisa/util/verify_collection.hpp
+++ b/include/pisa/util/verify_collection.hpp
@@ -12,7 +12,7 @@ template <typename InputCollection, typename Collection>
 void verify_collection(InputCollection const& input, const char* filename)
 {
     Collection coll;
-    auto source = MemorySource::mapped_file(boost::filesystem::path(filename));
+    auto source = MemorySource::mapped_file(std::filesystem::path(filename));
     pisa::mapper::map(coll, source.data());
     size_t size = 0;
     spdlog::info("Checking the written data, just to be extra safe...");

--- a/src/forward_index_builder.cpp
+++ b/src/forward_index_builder.cpp
@@ -266,11 +266,10 @@ void Forward_Index_Builder::build(
     remove_batches(output_file, batch_number);
 }
 
-void try_remove(boost::filesystem::path const& file)
+void try_remove(std::filesystem::path const& file)
 {
-    using boost::filesystem::remove;
     try {
-        remove(file);
+        std::filesystem::remove(file);
     } catch (...) {
         spdlog::warn("Unable to remove temporary batch file {}", file.c_str());
     }
@@ -278,13 +277,12 @@ void try_remove(boost::filesystem::path const& file)
 
 void Forward_Index_Builder::remove_batches(std::string const& basename, std::ptrdiff_t batch_count) const
 {
-    using boost::filesystem::path;
     for (auto batch: ranges::views::iota(0, batch_count)) {
         auto batch_basename = batch_file(basename, batch);
-        try_remove(path{batch_basename + ".documents"});
-        try_remove(path{batch_basename + ".terms"});
-        try_remove(path{batch_basename + ".urls"});
-        try_remove(path{batch_basename});
+        try_remove(std::filesystem::path{batch_basename + ".documents"});
+        try_remove(std::filesystem::path{batch_basename + ".terms"});
+        try_remove(std::filesystem::path{batch_basename + ".urls"});
+        try_remove(std::filesystem::path{batch_basename});
     }
 }
 

--- a/src/invert.cpp
+++ b/src/invert.cpp
@@ -2,7 +2,6 @@
 #include <sstream>
 #include <vector>
 
-#include <boost/filesystem.hpp>
 #include <spdlog/spdlog.h>
 #include <tbb/parallel_reduce.h>
 
@@ -253,9 +252,9 @@ namespace pisa { namespace invert {
             std::ostringstream batch_name_stream;
             batch_name_stream << output_basename << ".batch." << batch;
             auto batch_basename = batch_name_stream.str();
-            boost::filesystem::remove(boost::filesystem::path{batch_basename + ".docs"});
-            boost::filesystem::remove(boost::filesystem::path{batch_basename + ".freqs"});
-            boost::filesystem::remove(boost::filesystem::path{batch_basename + ".sizes"});
+            std::filesystem::remove(std::filesystem::path{batch_basename + ".docs"});
+            std::filesystem::remove(std::filesystem::path{batch_basename + ".freqs"});
+            std::filesystem::remove(std::filesystem::path{batch_basename + ".sizes"});
         }
     }
 

--- a/src/io.cpp
+++ b/src/io.cpp
@@ -1,3 +1,5 @@
+#include <fstream>
+
 #include <fmt/format.h>
 
 #include "io.hpp"
@@ -12,10 +14,10 @@ NoSuchFile::NoSuchFile(std::string const& file) : m_message(fmt::format("No such
     return m_message.c_str();
 }
 
-auto resolve_path(std::string const& file) -> boost::filesystem::path
+auto resolve_path(std::string const& file) -> std::filesystem::path
 {
-    boost::filesystem::path p(file);
-    if (not boost::filesystem::exists(p)) {
+    std::filesystem::path p(file);
+    if (not std::filesystem::exists(p)) {
         throw NoSuchFile(file);
     }
     return p;

--- a/src/memory_source.cpp
+++ b/src/memory_source.cpp
@@ -23,9 +23,9 @@ auto MemorySource::mapped_file(std::string const& file) -> MemorySource
     return MemorySource::mapped_file(io::resolve_path(file));
 }
 
-auto MemorySource::mapped_file(boost::filesystem::path file) -> MemorySource
+auto MemorySource::mapped_file(std::filesystem::path file) -> MemorySource
 {
-    if (not boost::filesystem::exists(file)) {
+    if (not std::filesystem::exists(file)) {
         throw io::NoSuchFile(file.string());
     }
     return MemorySource(mio::mmap_source(file.string().c_str()));

--- a/src/sharding.cpp
+++ b/src/sharding.cpp
@@ -40,8 +40,8 @@ auto resolve_shards(std::string_view basename, std::string_view suffix) -> std::
     Shard_Id shard{0};
     std::vector<Shard_Id> shards;
     while (true) {
-        boost::filesystem::path p(fmt::format("{}{}", expand_shard(basename, shard), suffix));
-        if (boost::filesystem::exists(p)) {
+        std::filesystem::path p(fmt::format("{}{}", expand_shard(basename, shard), suffix));
+        if (std::filesystem::exists(p)) {
             shards.push_back(shard);
             shard += 1;
         } else {
@@ -93,7 +93,7 @@ auto mapping_from_files(std::string const& full_titles, gsl::span<std::string co
     std::ifstream fis(full_titles);
     std::vector<std::unique_ptr<std::istream>> shard_is;
     for (auto const& shard_file: shard_titles) {
-        if (!boost::filesystem::exists(shard_file)) {
+        if (!std::filesystem::exists(shard_file)) {
             throw std::invalid_argument(fmt::format("Shard file does not exist: {}", shard_file));
         }
         shard_is.push_back(std::make_unique<std::ifstream>(shard_file));

--- a/test/docker/clang16/Dockerfile
+++ b/test/docker/clang16/Dockerfile
@@ -5,7 +5,7 @@ ARG USE_SANITIZERS=OFF
 ARG DEBIAN_FRONTEND=noninteractive
 
 COPY /test/docker/install-clang.sh /
-RUN /install-clang.sh 15
+RUN /install-clang.sh 16
 RUN apt-get update -y \
      && apt-get install libboost-filesystem-dev=1.74.* libboost-dev=1.74.* -y --no-install-recommends \
      && apt-get clean \

--- a/test/test_forward_index_builder.cpp
+++ b/test/test_forward_index_builder.cpp
@@ -2,9 +2,9 @@
 
 #include <algorithm>
 #include <cstdio>
+#include <filesystem>
 #include <string>
 
-#include <boost/filesystem.hpp>
 #include <catch2/catch.hpp>
 #include <gsl/span>
 
@@ -18,7 +18,6 @@
 #include "text_analyzer.hpp"
 #include "tokenizer.hpp"
 
-using namespace boost::filesystem;
 using namespace pisa;
 
 TEST_CASE("Batch file name", "[parsing][forward_index]")
@@ -172,7 +171,8 @@ TEST_CASE("Merge forward index batches", "[parsing][forward_index]")
     auto dir = tmpdir.path();
     GIVEN("Three batches on disk")
     {
-        std::vector<path> batch_paths{dir / "fwd.batch.0", dir / "fwd.batch.1", dir / "fwd.batch.2"};
+        std::vector<std::filesystem::path> batch_paths{
+            dir / "fwd.batch.0", dir / "fwd.batch.1", dir / "fwd.batch.2"};
         write_batch(
             batch_paths[0].string(),
             {"Doc10", "Doc11"},
@@ -327,7 +327,7 @@ TEST_CASE("Build forward index", "[parsing][forward_index][integration]")
     GIVEN("A plaintext collection file")
     {
         std::string input(PISA_SOURCE_DIR "/test/test_data/clueweb1k.plaintext");
-        REQUIRE(boost::filesystem::exists(boost::filesystem::path(input)) == true);
+        REQUIRE(std::filesystem::exists(std::filesystem::path(input)) == true);
         int thread_count = GENERATE(2, 8);
         int batch_size = GENERATE(123, 1000);
         WHEN("Build a forward index")

--- a/test/test_invert.cpp
+++ b/test/test_invert.cpp
@@ -4,7 +4,6 @@
 #include <cstdio>
 #include <string>
 
-#include <boost/filesystem.hpp>
 #include <gsl/span>
 #include <range/v3/view/iota.hpp>
 
@@ -15,7 +14,6 @@
 #include "pisa_config.hpp"
 #include "temporary_directory.hpp"
 
-using namespace boost::filesystem;
 using namespace pisa;
 using namespace pisa::literals;
 

--- a/test/test_partition_fwd_index.cpp
+++ b/test/test_partition_fwd_index.cpp
@@ -6,7 +6,6 @@
 #include <iostream>
 #include <string>
 
-#include <boost/filesystem.hpp>
 #include <fmt/ostream.h>
 #include <gsl/span>
 #include <range/v3/action/transform.hpp>
@@ -27,7 +26,6 @@
 #include "sharding.hpp"
 #include "temporary_directory.hpp"
 
-using namespace boost::filesystem;
 using namespace pisa;
 using namespace pisa::literals;
 

--- a/test/test_recursive_graph_bisection.cpp
+++ b/test/test_recursive_graph_bisection.cpp
@@ -68,7 +68,7 @@ TEST_CASE("Reorder documents with BP")
     GIVEN("Built a forward index and inverted")
     {
         std::string collection_input(PISA_SOURCE_DIR "/test/test_data/clueweb1k.plaintext");
-        REQUIRE(boost::filesystem::exists(boost::filesystem::path(collection_input)) == true);
+        REQUIRE(std::filesystem::exists(std::filesystem::path(collection_input)) == true);
         int thread_count = 2;
         int batch_size = 1000;
         pisa::invert::InvertParams params;

--- a/test/test_taily_stats.cpp
+++ b/test/test_taily_stats.cpp
@@ -20,7 +20,7 @@
 
 using taily::Feature_Statistics;
 
-void write_documents(boost::filesystem::path const& path)
+void write_documents(std::filesystem::path const& path)
 {
     pisa::io::write_data(
         path.string(),
@@ -39,7 +39,7 @@ void write_documents(boost::filesystem::path const& path)
         }));
 }
 
-void write_frequencies(boost::filesystem::path const& path)
+void write_frequencies(std::filesystem::path const& path)
 {
     pisa::io::write_data(
         path.string(),
@@ -56,7 +56,7 @@ void write_frequencies(boost::filesystem::path const& path)
         }));
 }
 
-void write_sizes(boost::filesystem::path const& path)
+void write_sizes(std::filesystem::path const& path)
 {
     pisa::io::write_data(
         path.string(),

--- a/tools/parse_collection.cpp
+++ b/tools/parse_collection.cpp
@@ -1,3 +1,4 @@
+#include <filesystem>
 #include <string>
 
 #include <CLI/CLI.hpp>
@@ -15,9 +16,9 @@ using namespace pisa;
 int main(int argc, char** argv)
 {
     auto valid_basename = [](std::string const& basename) {
-        boost::filesystem::path p(basename);
+        std::filesystem::path p(basename);
         auto parent = p.parent_path();
-        if (not boost::filesystem::exists(parent) or not boost::filesystem::is_directory(parent)) {
+        if (not std::filesystem::exists(parent) or not std::filesystem::is_directory(parent)) {
             return fmt::format(
                 "Basename {} invalid: path {} is not an existing directory",
                 basename,

--- a/tools/tests/test_app.cpp
+++ b/tools/tests/test_app.cpp
@@ -179,7 +179,7 @@ void test_analyzer(
     REQUIRE(actual == expected);
 }
 
-void write_lines(boost::filesystem::path const& path, std::vector<std::string> const& lines)
+void write_lines(std::filesystem::path const& path, std::vector<std::string> const& lines)
 {
     std::ofstream out(path.c_str());
     for (auto const& line: lines) {
@@ -256,7 +256,7 @@ TEST_CASE("Ranked Query", "[cli]")
 
     GIVEN("Non-existend input file path")
     {
-        auto queries = boost::filesystem::path("queries.txt");
+        auto queries = std::filesystem::path("queries.txt");
         THEN("File cannot be read and it throws")
         {
             REQUIRE_THROWS(parse(app, {"--queries", queries.string()}));


### PR DESCRIPTION
Together with `BOOST_NO_CXX98_FUNCTION_BASE`, newer version of Boost fix builds on newer Clang versions. Currently, the way we pull Boost automatically only allows 1.67, and this one will fail to compile. This needs to be addressed in the near feature as well.

---

Replace `boost::filesystem` with `std::filesystem`

`std::filesystem` is now supported in all of our supported platforms,
and Boost crashes on newer clang compilers.