### PR TITLE
`thread_local` Porter2

### DIFF
--- a/include/pisa/token_filter.hpp
+++ b/include/pisa/token_filter.hpp
@@ -41,8 +41,6 @@ class TokenFilter {
 };
 
 class Porter2Stemmer final: public TokenFilter {
-    porter2::Stemmer m_stemmer{};
-
   public:
     [[nodiscard]] auto filter(std::string_view input) const -> std::unique_ptr<TokenStream> override;
     [[nodiscard]] auto filter(std::string input) const -> std::unique_ptr<TokenStream> override;

--- a/src/token_filter.cpp
+++ b/src/token_filter.cpp
@@ -20,7 +20,8 @@ auto Porter2Stemmer::filter(std::string_view input) const -> std::unique_ptr<Tok
 
 auto Porter2Stemmer::filter(std::string input) const -> std::unique_ptr<TokenStream>
 {
-    return std::make_unique<SingleTokenStream>(m_stemmer.stem(input));
+    thread_local porter2::Stemmer stemmer{};
+    return std::make_unique<SingleTokenStream>(stemmer.stem(input));
 }
 
 auto Porter2Stemmer::filter(CowString input) const -> std::unique_ptr<TokenStream>

--- a/tools/parse_collection.cpp
+++ b/tools/parse_collection.cpp
@@ -30,7 +30,6 @@ int main(int argc, char** argv)
     std::string input_basename;
     std::string output_filename;
     std::string format = "plaintext";
-    size_t threads = std::thread::hardware_concurrency();
     ptrdiff_t batch_size = 100'000;
 
     pisa::App<pisa::arg::LogLevel, pisa::arg::Threads, pisa::arg::Analyzer> app{
@@ -56,8 +55,8 @@ int main(int argc, char** argv)
 
     spdlog::set_level(app.log_level());
 
-    tbb::global_control control(tbb::global_control::max_allowed_parallelism, threads + 1);
-    spdlog::info("Number of worker threads: {}", threads);
+    tbb::global_control control(tbb::global_control::max_allowed_parallelism, app.threads() + 1);
+    spdlog::info("Number of worker threads: {}", app.threads());
 
     try {
         Forward_Index_Builder builder;
@@ -70,7 +69,7 @@ int main(int argc, char** argv)
                 record_parser(format, std::cin),
                 std::make_shared<TextAnalyzer>(app.text_analyzer()),
                 batch_size,
-                threads);
+                app.threads() + 1);
         }
     } catch (std::exception& err) {
         spdlog::error(err.what());


### PR DESCRIPTION
The stemmer is not thread-safe, so in order to make the wrapper class thread-safe, we use define it as `thread_local` in the `filter` function.

Fixes #524 
