### PR TITLE
Add byte padding to block index after postings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,7 @@ option(PISA_ENABLE_CLANG_TIDY "Enable static analysis with clang-tidy" OFF)
 option(PISA_CLANG_TIDY_EXECUTABLE "clang-tidy executable path" "clang-tidy")
 option(PISA_USE_PIC "Enable Position-Independent code globally" ON)
 option(PISA_CI_BUILD "Remove debug information from Debug build" OFF)
+option(PISA_SANITIZERS "Compile with address and UB sanitizers" OFF)
 
 option(PISA_SYSTEM_GOOGLE_BENCHMARK "Use system installation of Google benchmark library" OFF)
 option(PISA_SYSTEM_ONETBB "Use system installation of oneTBB" OFF)
@@ -73,7 +74,7 @@ if (UNIX)
    # Extensive warnings
    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wno-missing-braces")
 
-   if (USE_SANITIZERS)
+   if (PISA_SANITIZERS)
      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=undefined -fsanitize=address -fno-omit-frame-pointer")
    endif ()
 

--- a/include/pisa/block_freq_index.hpp
+++ b/include/pisa/block_freq_index.hpp
@@ -262,7 +262,7 @@ class block_freq_index {
          */
         void build(std::string const& index_path)
         {
-            // This is a workaround to QMS codex having to sometimes look beyond the buffer
+            // This is a workaround to QMX codex having to sometimes look beyond the buffer
             // due to some SIMD loads.
             std::array<char, 15> padding{};
             m_postings_output.write(padding.data(), padding.size());

--- a/include/pisa/block_freq_index.hpp
+++ b/include/pisa/block_freq_index.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <array>
 #include <exception>
 
 #include <fmt/format.h>
@@ -134,6 +135,11 @@ class block_freq_index {
             sq.m_params = m_params;
             sq.m_size = m_endpoints.size() - 1;
             sq.m_num_docs = m_num_docs;
+
+            // This is a workaround to QMS codex having to sometimes look beyond the buffer
+            // due to some SIMD loads.
+            std::array<char, 15> padding{};
+            m_lists.insert(m_lists.end(), padding.begin(), padding.end());
             sq.m_lists.steal(m_lists);
 
             bit_vector_builder bvb;
@@ -256,6 +262,12 @@ class block_freq_index {
          */
         void build(std::string const& index_path)
         {
+            // This is a workaround to QMS codex having to sometimes look beyond the buffer
+            // due to some SIMD loads.
+            std::array<char, 15> padding{};
+            m_postings_output.write(padding.data(), padding.size());
+            m_postings_bytes_written += padding.size();
+
             std::ofstream os(index_path.c_str());
             std::cout << index_path.c_str() << "\n";
             os.exceptions(std::ios::badbit | std::ios::failbit);

--- a/include/pisa/block_freq_index.hpp
+++ b/include/pisa/block_freq_index.hpp
@@ -136,7 +136,7 @@ class block_freq_index {
             sq.m_size = m_endpoints.size() - 1;
             sq.m_num_docs = m_num_docs;
 
-            // This is a workaround to QMS codex having to sometimes look beyond the buffer
+            // This is a workaround to QMX codex having to sometimes look beyond the buffer
             // due to some SIMD loads.
             std::array<char, 15> padding{};
             m_lists.insert(m_lists.end(), padding.begin(), padding.end());

--- a/include/pisa/codec/qmx.hpp
+++ b/include/pisa/codec/qmx.hpp
@@ -23,6 +23,13 @@ struct qmx_block {
         TightVariableByte::encode_single(out_len, out);
         out.insert(out.end(), buf.data(), buf.data() + out_len);
     }
+
+    /**
+     * NOTE: In order to be sure to avoid undefined behavior, `in` must be padded with 15 bytes
+     * because of 16-byte SIMD reads that could be called with the address of the last byte.
+     * This is NOT enforced by `encode`, because it would be very wasteful to add 15 bytes to each
+     * block. Instead, the padding is added to the index, after all postings.
+     */
     static uint8_t const* decode(uint8_t const* in, uint32_t* out, uint32_t sum_of_values, size_t n)
     {
         static QMX::compress_integer_qmx_improved qmx_codec;  // decodeBlock is thread-safe

--- a/test/docker/clang12/Dockerfile
+++ b/test/docker/clang12/Dockerfile
@@ -16,7 +16,7 @@ RUN cmake \
     -DPISA_BUILD_TOOLS='OFF' \
     -DPISA_ENABLE_BENCHMARKING='OFF' \
     -DCMAKE_TOOLCHAIN_FILE='clang.cmake' \
-    "-DUSE_SANITIZERS=$USE_SANITIZERS" \
+    "-DPISA_SANITIZERS=$USE_SANITIZERS" \
     "-DCMAKE_CXX_STANDARD=$CXX_STANDARD" \
     .. \
     && cmake --build . --config Debug -- -j 4

--- a/test/docker/clang15/Dockerfile
+++ b/test/docker/clang15/Dockerfile
@@ -21,7 +21,7 @@ RUN cmake \
     -DPISA_ENABLE_BENCHMARKING='OFF' \
     -DPISA_SYSTEM_BOOST='ON' \
     -DCMAKE_TOOLCHAIN_FILE='clang.cmake' \
-    "-DUSE_SANITIZERS=$USE_SANITIZERS" \
+    "-DPISA_SANITIZERS=$USE_SANITIZERS" \
     "-DCMAKE_CXX_STANDARD=$CXX_STANDARD" \
     .. \
     && cmake --build . --config Debug -- -j 4

--- a/test/docker/clang16/Dockerfile
+++ b/test/docker/clang16/Dockerfile
@@ -21,7 +21,7 @@ RUN cmake \
     -DPISA_ENABLE_BENCHMARKING='OFF' \
     -DPISA_SYSTEM_BOOST='ON' \
     -DCMAKE_TOOLCHAIN_FILE='clang.cmake' \
-    "-DUSE_SANITIZERS=$USE_SANITIZERS" \
+    "-DPISA_SANITIZERS=$USE_SANITIZERS" \
     "-DCMAKE_CXX_STANDARD=$CXX_STANDARD" \
     .. \
     && cmake --build . --config Debug -- -j 4

--- a/test/docker/gcc10/Dockerfile
+++ b/test/docker/gcc10/Dockerfile
@@ -15,7 +15,7 @@ RUN cmake \
     "-DCMAKE_BUILD_TYPE=Debug" \
     "-DPISA_BUILD_TOOLS=OFF" \
     "-DPISA_ENABLE_BENCHMARKING=OFF" \
-    "-DUSE_SANITIZERS=$USE_SANITIZERS" \
+    "-DPISA_SANITIZERS=$USE_SANITIZERS" \
     "-DCMAKE_CXX_STANDARD=$CXX_STANDARD" \
     .. \
     && cmake --build . --config Debug -- -j 4

--- a/test/docker/gcc11/Dockerfile
+++ b/test/docker/gcc11/Dockerfile
@@ -15,7 +15,7 @@ RUN cmake \
     "-DCMAKE_BUILD_TYPE=Debug" \
     "-DPISA_BUILD_TOOLS=OFF" \
     "-DPISA_ENABLE_BENCHMARKING=OFF" \
-    "-DUSE_SANITIZERS=$USE_SANITIZERS" \
+    "-DPISA_SANITIZERS=$USE_SANITIZERS" \
     "-DCMAKE_CXX_STANDARD=$CXX_STANDARD" \
     .. \
     && cmake --build . --config Debug -- -j 4

--- a/test/docker/gcc12/Dockerfile
+++ b/test/docker/gcc12/Dockerfile
@@ -15,7 +15,7 @@ RUN cmake \
     "-DCMAKE_BUILD_TYPE=Debug" \
     "-DPISA_BUILD_TOOLS=OFF" \
     "-DPISA_ENABLE_BENCHMARKING=OFF" \
-    "-DUSE_SANITIZERS=$USE_SANITIZERS" \
+    "-DPISA_SANITIZERS=$USE_SANITIZERS" \
     "-DCMAKE_CXX_STANDARD=$CXX_STANDARD" \
     .. \
     && cmake --build . --config Debug -- -j 4

--- a/test/docker/gcc13/Dockerfile
+++ b/test/docker/gcc13/Dockerfile
@@ -15,7 +15,7 @@ RUN cmake \
     "-DCMAKE_BUILD_TYPE=Debug" \
     "-DPISA_BUILD_TOOLS=OFF" \
     "-DPISA_ENABLE_BENCHMARKING=OFF" \
-    "-DUSE_SANITIZERS=$USE_SANITIZERS" \
+    "-DPISA_SANITIZERS=$USE_SANITIZERS" \
     "-DCMAKE_CXX_STANDARD=$CXX_STANDARD" \
     .. \
     && cmake --build . --config Debug -- -j 4

--- a/test/docker/gcc9/Dockerfile
+++ b/test/docker/gcc9/Dockerfile
@@ -15,7 +15,7 @@ RUN cmake \
     "-DCMAKE_BUILD_TYPE=Debug" \
     "-DPISA_BUILD_TOOLS=OFF" \
     "-DPISA_ENABLE_BENCHMARKING=OFF" \
-    "-DUSE_SANITIZERS=$USE_SANITIZERS" \
+    "-DPISA_SANITIZERS=$USE_SANITIZERS" \
     "-DCMAKE_CXX_STANDARD=$CXX_STANDARD" \
     .. \
     && cmake --build . --config Debug -- -j 4


### PR DESCRIPTION
QMX can call SIMD reads with the address of the last byte in a block, which causes undefined behavior (read after buffer) if it happens at the end of the index memory. This commit adds 15 bytes at the very end of the index to avoid UB. Also, block codecs tests are adapted so that we always have 15-byte padding for QMX.

Fixes #541 
