### PR TITLE
Fix ranked_or_taat and ranked_or_taat_lazy

### DIFF
--- a/tools/queries.cpp
+++ b/tools/queries.cpp
@@ -273,8 +273,8 @@ void perftest(
         } else if (t == "ranked_or_taat" && wand_data_filename) {
             SimpleAccumulator accumulator(index.num_docs());
             topk_queue topk(k);
-            ranked_or_taat_query ranked_or_taat_q(topk);
-            query_fun = [&, ranked_or_taat_q, accumulator](Query query, Score threshold) mutable {
+            query_fun = [&, topk, accumulator](Query query, Score threshold) mutable {
+                ranked_or_taat_query ranked_or_taat_q(topk);            
                 topk.clear(threshold);
                 ranked_or_taat_q(
                     make_scored_cursors(index, *scorer, query, weighted), index.num_docs(), accumulator
@@ -285,8 +285,8 @@ void perftest(
         } else if (t == "ranked_or_taat_lazy" && wand_data_filename) {
             LazyAccumulator<4> accumulator(index.num_docs());
             topk_queue topk(k);
-            ranked_or_taat_query ranked_or_taat_q(topk);
-            query_fun = [&, ranked_or_taat_q, accumulator](Query query, Score threshold) mutable {
+            query_fun = [&, topk, accumulator](Query query, Score threshold) mutable {
+                ranked_or_taat_query ranked_or_taat_q(topk);
                 topk.clear(threshold);
                 ranked_or_taat_q(
                     make_scored_cursors(index, *scorer, query, weighted), index.num_docs(), accumulator

--- a/tools/queries.cpp
+++ b/tools/queries.cpp
@@ -274,7 +274,7 @@ void perftest(
             SimpleAccumulator accumulator(index.num_docs());
             topk_queue topk(k);
             query_fun = [&, topk, accumulator](Query query, Score threshold) mutable {
-                ranked_or_taat_query ranked_or_taat_q(topk);            
+                ranked_or_taat_query ranked_or_taat_q(topk);
                 topk.clear(threshold);
                 ranked_or_taat_q(
                     make_scored_cursors(index, *scorer, query, weighted), index.num_docs(), accumulator


### PR DESCRIPTION
Currently `ranked_or_taat` and `ranked_or_taat_lazy` fail with segfault, this change should fix them.
