### PR TITLE
Source setvars.sh when installing TBB from package

### DIFF
--- a/test/docker/system-deps/Dockerfile
+++ b/test/docker/system-deps/Dockerfile
@@ -23,7 +23,7 @@ RUN ./pisa/test/docker/install-cmake.sh
 
 RUN mkdir /pisa/build
 WORKDIR /pisa/build
-RUN cmake \
+RUN . /opt/intel/oneapi/setvars.sh && cmake \
     "-DCMAKE_BUILD_TYPE=Debug" \
     "-DPISA_BUILD_TOOLS=ON" \
     "-DPISA_ENABLE_BENCHMARKING=ON" \


### PR DESCRIPTION
It is now required to source /opt/intel/oneapi/setvars.sh in shell to populate all needed variables for discovery via CMake.