### PR TITLE
Concepts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,7 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 if(NOT CMAKE_CXX_STANDARD EQUAL 17)
     add_compile_definitions(PISA_ENABLE_CONCEPTS=1)
     add_compile_definitions(PISA_CXX20=1)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fconcepts-diagnostics-depth=2")
 endif()
 add_compile_definitions(BOOST_NO_CXX98_FUNCTION_BASE=1)
 

--- a/include/pisa/block_freq_index.hpp
+++ b/include/pisa/block_freq_index.hpp
@@ -8,6 +8,8 @@
 #include "bit_vector.hpp"
 #include "block_posting_list.hpp"
 #include "codec/compact_elias_fano.hpp"
+#include "concepts.hpp"
+#include "concepts/inverted_index.hpp"
 #include "mappable/mappable_vector.hpp"
 #include "mappable/mapper.hpp"
 #include "memory_source.hpp"
@@ -44,6 +46,9 @@ class block_freq_index {
      *                any index operations may result in undefined behavior.
      */
     explicit block_freq_index(MemorySource source) : m_source(std::move(source)) {
+        PISA_ASSERT_CONCEPT((concepts::SortedInvertedIndex<
+                             block_freq_index,
+                             typename block_posting_list<BlockCodec, Profile>::document_enumerator>));
         mapper::map(*this, m_source.data(), mapper::map_flags::warmup);
     }
 

--- a/include/pisa/block_posting_list.hpp
+++ b/include/pisa/block_posting_list.hpp
@@ -1,6 +1,8 @@
 #pragma once
 
 #include "codec/block_codecs.hpp"
+#include "concepts.hpp"
+#include "concepts/posting_cursor.hpp"
 #include "util/block_profiler.hpp"
 #include "util/util.hpp"
 
@@ -86,6 +88,11 @@ struct block_posting_list {
               m_block_endpoints(m_block_maxs + 4 * m_blocks),
               m_blocks_data(m_block_endpoints + 4 * (m_blocks - 1)),
               m_universe(universe) {
+            PISA_ASSERT_CONCEPT(
+                (concepts::FrequencyPostingCursor<document_enumerator>
+                 && concepts::SortedPostingCursor<document_enumerator>)
+            );
+
             if (Profile) {
                 // std::cout << "OPEN\t" << m_term_id << "\t" << m_blocks << "\n";
                 m_block_profile = block_profiler::open_list(term_id, m_blocks);
@@ -159,9 +166,11 @@ struct block_posting_list {
             return m_freqs_buf[m_pos_in_block] + 1;
         }
 
+        uint64_t PISA_ALWAYSINLINE value() { return freq(); }
+
         uint64_t position() const { return m_cur_block * BlockCodec::block_size + m_pos_in_block; }
 
-        uint64_t size() const { return m_n; }
+        uint64_t size() const noexcept { return m_n; }
 
         uint64_t num_blocks() const { return m_blocks; }
 

--- a/include/pisa/concepts/container.hpp
+++ b/include/pisa/concepts/container.hpp
@@ -1,0 +1,39 @@
+
+// Copyright 2024 PISA developers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// clang-format off
+
+#pragma once
+
+#ifdef PISA_ENABLE_CONCEPTS
+
+#include <concepts>
+
+namespace pisa::concepts {
+
+/**
+ * Any container with a size.
+ */
+template <typename T>
+concept SizedContainer = requires(T const container) {
+    /** Returns the number of posting lists in the index. */
+    { container.size() }  noexcept -> std::convertible_to<std::size_t>;
+};
+
+};  // namespace pisa
+
+// clang-format on
+
+#endif

--- a/include/pisa/concepts/inverted_index.hpp
+++ b/include/pisa/concepts/inverted_index.hpp
@@ -1,0 +1,52 @@
+// Copyright 2024 PISA developers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+// clang-format off
+
+#ifdef PISA_ENABLE_CONCEPTS
+
+#include <concepts>
+#include <cstdint>
+
+#include "container.hpp"
+#include "posting_cursor.hpp"
+
+namespace pisa::concepts {
+
+/**
+ * Inverted index is a collection of posting lists.
+ */
+template <typename T, typename Cursor>
+concept InvertedIndex = PostingCursor<Cursor> && SizedContainer<T>
+&& requires(T const i, std::uint32_t termid) {
+    /** Accesses a posting list via a cursor. */
+    { i.operator[](termid) } -> std::same_as<Cursor>;
+
+    /** Returns the number of indexed documents. */
+    { i.num_docs() } noexcept -> std::convertible_to<std::size_t>;
+};
+
+/**
+ * Inverted index that stores postings sorted by document IDs.
+ */
+template <typename T, typename Cursor>
+concept SortedInvertedIndex = InvertedIndex<T, Cursor> && SortedPostingCursor<Cursor>;
+
+};  // namespace pisa
+
+// clang-format on
+
+#endif

--- a/include/pisa/concepts/mapping.hpp
+++ b/include/pisa/concepts/mapping.hpp
@@ -1,0 +1,63 @@
+// Copyright 2024 PISA developers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// clang-format off
+
+#pragma once
+
+#ifdef PISA_ENABLE_CONCEPTS
+
+#include <concepts>
+#include <cstdint>
+#include <optional>
+
+namespace pisa::concepts {
+
+/**
+ * Mapping from an integer to a payload value.
+ *
+ * One of the examples is a mapping from document ID to document title or URL.
+ */
+template <typename T, typename Payload>
+concept Mapping = requires(T const map, std::uint32_t pos) {
+    /** Get payload at position `pos`. */
+    { map[pos] } -> std::convertible_to<Payload>;
+
+    /** Returns the number of posting lists in the index. */
+    { map.size() }  noexcept -> std::convertible_to<std::size_t>;
+};
+
+/**
+ * Mapping from a payload value to ordinal ID.
+ */
+template <typename T, typename Payload>
+concept ReverseMapping = requires(T const map, Payload payload) {
+    /** Get the position of the given payload. */
+    { map.find(payload) } -> std::convertible_to<std::optional<std::uint32_t>>;
+};
+
+/**
+ * Mapping from an integer to a payload value and back.
+ *
+ * One of the examples is a term lexicon, which maps from term IDs to terms and back.
+ * The backwards mapping can be used to look up term IDs after parsing a query to term tokens.
+ */
+template <typename T, typename Payload>
+concept BidirectionalMapping = Mapping<T, Payload> && ReverseMapping<T, Payload>;
+
+};  // namespace pisa
+
+// clang-format on
+
+#endif

--- a/include/pisa/concepts/posting_cursor.hpp
+++ b/include/pisa/concepts/posting_cursor.hpp
@@ -1,0 +1,99 @@
+// Copyright 2024 PISA developers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// clang-format off
+
+#pragma once
+
+#ifdef PISA_ENABLE_CONCEPTS
+
+#include <concepts>
+#include <cstdint>
+
+#include "container.hpp"
+#include "type_alias.hpp"
+
+namespace pisa::concepts {
+
+/**
+ * A posting cursor iterates over a posting list.
+ */
+template <typename C>
+concept PostingCursor = SizedContainer<C> && requires(C const &cursor)
+{
+    /** Returns the document ID at the current position. */
+    { cursor.docid() } -> std::convertible_to<std::uint32_t>;
+} && requires(C cursor) {
+    /** Moves the cursor to the next position. */
+    cursor.next();
+};
+
+/**
+ * A posting cursor returning a score.
+ */
+template <typename C>
+concept FrequencyPostingCursor = PostingCursor<C>  && requires(C cursor) {
+    /** Returns the value of the payload. */
+    { cursor.freq() } -> std::convertible_to<std::uint32_t>;
+};
+
+/**
+ * A posting cursor returning a score.
+ */
+template <typename C>
+concept ScoredPostingCursor = PostingCursor<C>  && requires(C cursor) {
+    /** Returns the value of the payload. */
+    { cursor.score() } -> std::convertible_to<Score>;
+};
+
+/**
+ * A cursor over a posting list that stores postings in increasing order of document IDs.
+ */
+template <typename C>
+concept SortedPostingCursor = PostingCursor<C>
+&& requires(C cursor, std::uint32_t docid) {
+    /**
+     * Moves the cursor to the next position at which the document ID is at least `docid`.
+     * If the current ID already satisfies this condition, the cursor will not move. It will
+     * never move backwards.
+     */
+    cursor.next_geq(docid);
+};
+
+/**
+ * A posting cursor with max score.
+ */
+template <typename C>
+concept MaxScorePostingCursor = ScoredPostingCursor<C> && requires(C const& cursor) {
+    /** Returns the max score of the entire list. */
+    { cursor.max_score() } noexcept -> std::convertible_to<Score>;
+};
+
+/**
+ * A posting cursor with block-max scores.
+ */
+template <typename C>
+concept BlockMaxPostingCursor = MaxScorePostingCursor<C> && SortedPostingCursor<C>
+&& requires(C cursor) {
+    /** Returns the max highest docid of the current block. */
+    { cursor.block_max_docid() } -> std::convertible_to<DocId>;
+    /** Returns the max score of the current block. */
+    { cursor.block_max_score() } -> std::convertible_to<Score>;
+};
+
+};  // namespace pisa
+
+// clang-format on
+
+#endif

--- a/include/pisa/cursor/block_max_scored_cursor.hpp
+++ b/include/pisa/cursor/block_max_scored_cursor.hpp
@@ -10,6 +10,7 @@
 namespace pisa {
 
 template <typename Cursor, typename Wand>
+PISA_REQUIRES((concepts::FrequencyPostingCursor<Cursor> && concepts::SortedPostingCursor<Cursor>))
 class BlockMaxScoredCursor: public MaxScoredCursor<Cursor> {
   public:
     using base_cursor_type = Cursor;
@@ -22,7 +23,9 @@ class BlockMaxScoredCursor: public MaxScoredCursor<Cursor> {
         typename Wand::wand_data_enumerator wdata
     )
         : MaxScoredCursor<Cursor>(std::move(cursor), std::move(term_scorer), weight, max_score),
-          m_wdata(std::move(wdata)) {}
+          m_wdata(std::move(wdata)) {
+        PISA_ASSERT_CONCEPT((concepts::BlockMaxPostingCursor<BlockMaxScoredCursor>));
+    }
     BlockMaxScoredCursor(BlockMaxScoredCursor const&) = delete;
     BlockMaxScoredCursor(BlockMaxScoredCursor&&) = default;
     BlockMaxScoredCursor& operator=(BlockMaxScoredCursor const&) = delete;

--- a/include/pisa/cursor/max_scored_cursor.hpp
+++ b/include/pisa/cursor/max_scored_cursor.hpp
@@ -9,13 +9,19 @@
 namespace pisa {
 
 template <typename Cursor>
+PISA_REQUIRES((concepts::FrequencyPostingCursor<Cursor> && concepts::SortedPostingCursor<Cursor>))
 class MaxScoredCursor: public ScoredCursor<Cursor> {
   public:
     using base_cursor_type = Cursor;
 
     MaxScoredCursor(Cursor cursor, TermScorer term_scorer, float weight, float max_score)
         : ScoredCursor<Cursor>(std::move(cursor), std::move(term_scorer), weight),
-          m_max_score(max_score) {}
+          m_max_score(max_score) {
+        PISA_ASSERT_CONCEPT(
+            (concepts::MaxScorePostingCursor<MaxScoredCursor>
+             && concepts::SortedPostingCursor<MaxScoredCursor>)
+        );
+    }
     MaxScoredCursor(MaxScoredCursor const&) = delete;
     MaxScoredCursor(MaxScoredCursor&&) = default;
     MaxScoredCursor& operator=(MaxScoredCursor const&) = delete;

--- a/include/pisa/freq_index.hpp
+++ b/include/pisa/freq_index.hpp
@@ -4,9 +4,9 @@
 #include <tbb/parallel_invoke.h>
 
 #include "bitvector_collection.hpp"
-#include "codec/compact_elias_fano.hpp"
 #include "codec/integer_codes.hpp"
 #include "concepts.hpp"
+#include "concepts/inverted_index.hpp"
 #include "concepts/posting_cursor.hpp"
 #include "global_parameters.hpp"
 #include "mappable/mapper.hpp"
@@ -43,6 +43,9 @@ class freq_index {
      *                any index operations may result in undefined behavior.
      */
     explicit freq_index(MemorySource source) : m_source(std::move(source)) {
+        PISA_ASSERT_CONCEPT(
+            (concepts::SortedInvertedIndex<freq_index, typename freq_index::document_enumerator>)
+        );
         mapper::map(*this, m_source.data(), mapper::map_flags::warmup);
     }
 

--- a/include/pisa/freq_index.hpp
+++ b/include/pisa/freq_index.hpp
@@ -6,6 +6,8 @@
 #include "bitvector_collection.hpp"
 #include "codec/compact_elias_fano.hpp"
 #include "codec/integer_codes.hpp"
+#include "concepts.hpp"
+#include "concepts/posting_cursor.hpp"
 #include "global_parameters.hpp"
 #include "mappable/mapper.hpp"
 #include "memory_source.hpp"
@@ -157,9 +159,11 @@ class freq_index {
 
         uint64_t PISA_FLATTEN_FUNC freq() { return m_freqs_enum.move(m_cur_pos).second; }
 
+        uint64_t PISA_FLATTEN_FUNC value() { return freq(); }
+
         uint64_t position() const { return m_cur_pos; }
 
-        uint64_t size() const { return m_docs_enum.size(); }
+        uint64_t size() const noexcept { return m_docs_enum.size(); }
 
         typename DocsSequence::enumerator const& docs_enum() const { return m_docs_enum; }
 
@@ -172,6 +176,10 @@ class freq_index {
             typename DocsSequence::enumerator docs_enum, typename FreqsSequence::enumerator freqs_enum
         )
             : m_docs_enum(docs_enum), m_freqs_enum(freqs_enum) {
+            PISA_ASSERT_CONCEPT(
+                (concepts::FrequencyPostingCursor<document_enumerator>
+                 && concepts::SortedPostingCursor<document_enumerator>)
+            );
             reset();
         }
 

--- a/include/pisa/query/algorithm/and_query.hpp
+++ b/include/pisa/query/algorithm/and_query.hpp
@@ -4,6 +4,9 @@
 #include <cstdint>
 #include <vector>
 
+#include "concepts.hpp"
+#include "concepts/posting_cursor.hpp"
+
 namespace pisa {
 
 /**
@@ -15,6 +18,7 @@ namespace pisa {
  */
 struct and_query {
     template <typename CursorRange>
+    PISA_REQUIRES((concepts::SortedPostingCursor<typename CursorRange::value_type>))
     auto operator()(CursorRange&& cursors, uint32_t max_docid) const {
         using Cursor = typename std::decay_t<CursorRange>::value_type;
 

--- a/include/pisa/query/algorithm/block_max_maxscore_query.hpp
+++ b/include/pisa/query/algorithm/block_max_maxscore_query.hpp
@@ -2,6 +2,8 @@
 
 #include <vector>
 
+#include "concepts.hpp"
+#include "concepts/posting_cursor.hpp"
 #include "topk_queue.hpp"
 
 namespace pisa {
@@ -10,6 +12,7 @@ struct block_max_maxscore_query {
     explicit block_max_maxscore_query(topk_queue& topk) : m_topk(topk) {}
 
     template <typename CursorRange>
+    PISA_REQUIRES((concepts::BlockMaxPostingCursor<pisa::val_t<CursorRange>>))
     void operator()(CursorRange&& cursors, uint64_t max_docid) {
         using Cursor = typename std::decay_t<CursorRange>::value_type;
         if (cursors.empty()) {

--- a/include/pisa/query/algorithm/block_max_ranked_and_query.hpp
+++ b/include/pisa/query/algorithm/block_max_ranked_and_query.hpp
@@ -2,6 +2,8 @@
 
 #include <vector>
 
+#include "concepts.hpp"
+#include "concepts/posting_cursor.hpp"
 #include "topk_queue.hpp"
 
 namespace pisa {
@@ -10,6 +12,7 @@ struct block_max_ranked_and_query {
     explicit block_max_ranked_and_query(topk_queue& topk) : m_topk(topk) {}
 
     template <typename CursorRange>
+    PISA_REQUIRES(concepts::BlockMaxPostingCursor<pisa::val_t<CursorRange>>)
     void operator()(CursorRange&& cursors, uint64_t max_docid) {
         using Cursor = typename std::decay_t<CursorRange>::value_type;
 

--- a/include/pisa/query/algorithm/block_max_wand_query.hpp
+++ b/include/pisa/query/algorithm/block_max_wand_query.hpp
@@ -2,6 +2,8 @@
 
 #include <vector>
 
+#include "concepts.hpp"
+#include "concepts/posting_cursor.hpp"
 #include "topk_queue.hpp"
 
 namespace pisa {
@@ -10,6 +12,7 @@ struct block_max_wand_query {
     explicit block_max_wand_query(topk_queue& topk) : m_topk(topk) {}
 
     template <typename CursorRange>
+    PISA_REQUIRES(concepts::BlockMaxPostingCursor<pisa::val_t<CursorRange>>)
     void operator()(CursorRange&& cursors, uint64_t max_docid) {
         using Cursor = typename std::decay_t<CursorRange>::value_type;
         if (cursors.empty()) {

--- a/include/pisa/query/algorithm/or_query.hpp
+++ b/include/pisa/query/algorithm/or_query.hpp
@@ -4,6 +4,8 @@
 #include <cstdint>
 #include <type_traits>
 
+#include "concepts.hpp"
+#include "concepts/posting_cursor.hpp"
 #include "util/do_not_optimize_away.hpp"
 
 namespace pisa {
@@ -11,6 +13,7 @@ namespace pisa {
 template <bool with_freqs>
 struct or_query {
     template <typename CursorRange>
+    PISA_REQUIRES((concepts::SortedPostingCursor<typename CursorRange::value_type>))
     uint64_t operator()(CursorRange&& cursors, uint64_t max_docid) const {
         using Cursor = typename std::decay_t<CursorRange>::value_type;
         if (cursors.empty()) {

--- a/include/pisa/query/algorithm/range_query.hpp
+++ b/include/pisa/query/algorithm/range_query.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "concepts.hpp"
+#include "concepts/posting_cursor.hpp"
 #include "topk_queue.hpp"
 
 namespace pisa {
@@ -9,6 +11,7 @@ struct range_query {
     explicit range_query(topk_queue& topk) : m_topk(topk) {}
 
     template <typename CursorRange>
+    PISA_REQUIRES((concepts::MaxScorePostingCursor<typename std::decay_t<CursorRange>::value_type>))
     void operator()(CursorRange&& cursors, uint64_t max_docid, size_t range_size) {
         m_topk.clear();
         if (cursors.empty()) {
@@ -24,6 +27,7 @@ struct range_query {
     std::vector<typename topk_queue::entry_type> const& topk() const { return m_topk.topk(); }
 
     template <typename CursorRange>
+    PISA_REQUIRES((concepts::MaxScorePostingCursor<typename std::decay_t<CursorRange>::value_type>))
     void process_range(CursorRange&& cursors, size_t end) {
         QueryAlg query_alg(m_topk);
         query_alg(cursors, end);

--- a/include/pisa/query/algorithm/range_taat_query.hpp
+++ b/include/pisa/query/algorithm/range_taat_query.hpp
@@ -2,6 +2,7 @@
 
 #include "accumulator/partial_score_accumulator.hpp"
 #include "concepts.hpp"
+#include "concepts/posting_cursor.hpp"
 #include "topk_queue.hpp"
 
 namespace pisa {
@@ -11,8 +12,12 @@ struct range_taat_query {
     explicit range_taat_query(topk_queue& topk) : m_topk(topk) {}
 
     template <typename CursorRange, typename Acc>
-    PISA_REQUIRES(PartialScoreAccumulator<Acc>)
-    void operator()(CursorRange&& cursors, uint64_t max_docid, size_t range_size, Acc&& accumulator) {
+    PISA_REQUIRES(
+        (PartialScoreAccumulator<Acc>
+         && pisa::concepts::MaxScorePostingCursor<typename std::decay_t<CursorRange>::value_type>)
+    )
+    void
+    operator()(CursorRange&& cursors, uint64_t max_docid, size_t range_size, Acc&& accumulator) {
         if (cursors.empty()) {
             return;
         }

--- a/include/pisa/query/algorithm/ranked_and_query.hpp
+++ b/include/pisa/query/algorithm/ranked_and_query.hpp
@@ -2,6 +2,8 @@
 
 #include <vector>
 
+#include "concepts.hpp"
+#include "concepts/posting_cursor.hpp"
 #include "topk_queue.hpp"
 
 namespace pisa {
@@ -10,7 +12,12 @@ struct ranked_and_query {
     explicit ranked_and_query(topk_queue& topk) : m_topk(topk) {}
 
     template <typename CursorRange>
-    void operator()(CursorRange&& cursors, uint64_t max_docid) {
+    PISA_REQUIRES(
+        (concepts::ScoredPostingCursor<pisa::val_t<CursorRange>>
+         && concepts::SortedPostingCursor<pisa::val_t<CursorRange>>)
+    )
+    void
+    operator()(CursorRange&& cursors, uint64_t max_docid) {
         using Cursor = typename std::decay_t<CursorRange>::value_type;
         if (cursors.empty()) {
             return;

--- a/include/pisa/query/algorithm/ranked_or_query.hpp
+++ b/include/pisa/query/algorithm/ranked_or_query.hpp
@@ -2,6 +2,8 @@
 
 #include <vector>
 
+#include "concepts.hpp"
+#include "concepts/posting_cursor.hpp"
 #include "topk_queue.hpp"
 
 namespace pisa {
@@ -16,7 +18,12 @@ struct ranked_or_query {
     explicit ranked_or_query(topk_queue& topk) : m_topk(topk) {}
 
     template <typename CursorRange>
-    void operator()(CursorRange&& cursors, uint64_t max_docid) {
+    PISA_REQUIRES(
+        (concepts::ScoredPostingCursor<pisa::val_t<CursorRange>>
+         && concepts::SortedPostingCursor<pisa::val_t<CursorRange>>)
+    )
+    void
+    operator()(CursorRange&& cursors, uint64_t max_docid) {
         using Cursor = typename std::decay_t<CursorRange>::value_type;
         if (cursors.empty()) {
             return;

--- a/include/pisa/query/algorithm/ranked_or_taat_query.hpp
+++ b/include/pisa/query/algorithm/ranked_or_taat_query.hpp
@@ -2,6 +2,7 @@
 
 #include "accumulator/partial_score_accumulator.hpp"
 #include "concepts.hpp"
+#include "concepts/posting_cursor.hpp"
 #include "topk_queue.hpp"
 
 namespace pisa {
@@ -11,8 +12,12 @@ class ranked_or_taat_query {
     explicit ranked_or_taat_query(topk_queue& topk) : m_topk(topk) {}
 
     template <typename CursorRange, typename Acc>
-    PISA_REQUIRES(PartialScoreAccumulator<Acc>)
-    void operator()(CursorRange&& cursors, uint64_t max_docid, Acc&& accumulator) {
+    PISA_REQUIRES(
+        (PartialScoreAccumulator<Acc> && concepts::ScoredPostingCursor<pisa::val_t<CursorRange>>
+         && concepts::SortedPostingCursor<pisa::val_t<CursorRange>>)
+    )
+    void
+    operator()(CursorRange&& cursors, uint64_t max_docid, Acc&& accumulator) {
         if (cursors.empty()) {
             return;
         }

--- a/include/pisa/query/algorithm/wand_query.hpp
+++ b/include/pisa/query/algorithm/wand_query.hpp
@@ -2,6 +2,8 @@
 
 #include <vector>
 
+#include "concepts.hpp"
+#include "concepts/posting_cursor.hpp"
 #include "topk_queue.hpp"
 
 namespace pisa {
@@ -10,7 +12,12 @@ struct wand_query {
     explicit wand_query(topk_queue& topk) : m_topk(topk) {}
 
     template <typename CursorRange>
-    void operator()(CursorRange&& cursors, uint64_t max_docid) {
+    PISA_REQUIRES(
+        (concepts::MaxScorePostingCursor<pisa::val_t<CursorRange>>
+         && concepts::SortedPostingCursor<pisa::val_t<CursorRange>>)
+    )
+    void
+    operator()(CursorRange&& cursors, uint64_t max_docid) {
         using Cursor = typename std::decay_t<CursorRange>::value_type;
         if (cursors.empty()) {
             return;

--- a/include/pisa/term_map.hpp
+++ b/include/pisa/term_map.hpp
@@ -4,6 +4,9 @@
 #include <string>
 #include <string_view>
 
+#include "concepts.hpp"
+#include "concepts/container.hpp"
+#include "concepts/mapping.hpp"
 #include "payload_vector.hpp"
 
 namespace pisa {
@@ -17,21 +20,25 @@ class TermMap {
     TermMap& operator=(TermMap&&);
     virtual ~TermMap();
 
-    [[nodiscard]] virtual auto operator()(std::string_view term) -> std::optional<std::uint32_t> = 0;
-    [[nodiscard]] virtual auto operator()(std::string const& term)
+    [[nodiscard]] virtual auto find(std::string_view term) const -> std::optional<std::uint32_t> = 0;
+    [[nodiscard]] virtual auto find(std::string const& term) const
         -> std::optional<std::uint32_t> = 0;
 };
+
+PISA_ASSERT_CONCEPT((concepts::ReverseMapping<TermMap, std::string_view>));
 
 /**
  * Maps string representations of numbers to their numeric representations.
  */
 class IntMap final: public TermMap {
   public:
-    [[nodiscard]] virtual auto operator()(std::string_view term)
+    [[nodiscard]] virtual auto find(std::string_view term) const
         -> std::optional<std::uint32_t> override;
-    [[nodiscard]] virtual auto operator()(std::string const& term)
+    [[nodiscard]] virtual auto find(std::string const& term) const
         -> std::optional<std::uint32_t> override;
 };
+
+PISA_ASSERT_CONCEPT((concepts::ReverseMapping<IntMap, std::string_view>));
 
 class LexiconMap final: public TermMap {
     std::optional<Payload_Vector_Buffer> m_buffer;
@@ -41,10 +48,16 @@ class LexiconMap final: public TermMap {
     explicit LexiconMap(std::string const& file);
     explicit LexiconMap(Payload_Vector<std::string_view> lexicon);
 
-    [[nodiscard]] virtual auto operator()(std::string_view term)
+    [[nodiscard]] auto operator[](std::uint32_t term_id) const -> std::string_view;
+
+    [[nodiscard]] virtual auto find(std::string_view term) const
         -> std::optional<std::uint32_t> override;
-    [[nodiscard]] virtual auto operator()(std::string const& term)
+    [[nodiscard]] virtual auto find(std::string const& term) const
         -> std::optional<std::uint32_t> override;
+    [[nodiscard]] auto size() const noexcept -> std::size_t;
 };
+
+PISA_ASSERT_CONCEPT((concepts::BidirectionalMapping<LexiconMap, std::string_view>));
+PISA_ASSERT_CONCEPT((concepts::SizedContainer<LexiconMap>));
 
 }  // namespace pisa

--- a/include/pisa/type_alias.hpp
+++ b/include/pisa/type_alias.hpp
@@ -15,11 +15,15 @@
 #pragma once
 
 #include <cstdint>
+#include <type_traits>
 
 namespace pisa {
 
 using DocId = std::uint32_t;
 using TermId = std::uint32_t;
 using Score = float;
+
+template <typename Container>
+using val_t = typename std::decay_t<Container>::value_type;
 
 }  // namespace pisa

--- a/src/query/query_parser.cpp
+++ b/src/query/query_parser.cpp
@@ -30,7 +30,7 @@ auto QueryParser::parse(std::string_view query) -> Query {
     auto tokens = m_analyzer.analyze(raw_query);
     std::vector<TermId> term_ids;
     for (auto token: *tokens) {
-        if (auto tid = (*m_term_map)(token); tid) {
+        if (auto tid = m_term_map->find(token); tid) {
             term_ids.push_back(*tid);
         } else {
             spdlog::warn("Term `{}` not found and will be ignored", token);

--- a/src/term_map.cpp
+++ b/src/term_map.cpp
@@ -15,7 +15,7 @@ TermMap& TermMap::operator=(TermMap const&) = default;
 TermMap& TermMap::operator=(TermMap&&) = default;
 TermMap::~TermMap() = default;
 
-auto IntMap::operator()(std::string_view term) -> std::optional<std::uint32_t> {
+auto IntMap::find(std::string_view term) const -> std::optional<std::uint32_t> {
     std::uint32_t value;
     auto [ptr, ec] = std::from_chars(term.begin(), term.end(), value, 10);
     if (ec == std::errc::result_out_of_range || ec == std::errc::invalid_argument
@@ -25,8 +25,8 @@ auto IntMap::operator()(std::string_view term) -> std::optional<std::uint32_t> {
     return value;
 }
 
-auto IntMap::operator()(std::string const& term) -> std::optional<std::uint32_t> {
-    return (*this)(std::string_view(term));
+auto IntMap::find(std::string const& term) const -> std::optional<std::uint32_t> {
+    return this->find(std::string_view(term));
 }
 
 LexiconMap::LexiconMap(std::string const& file)
@@ -35,12 +35,20 @@ LexiconMap::LexiconMap(std::string const& file)
 LexiconMap::LexiconMap(Payload_Vector<std::string_view> lexicon)
     : m_buffer(std::nullopt), m_lexicon(lexicon) {}
 
-auto LexiconMap::operator()(std::string_view term) -> std::optional<std::uint32_t> {
+auto LexiconMap::find(std::string_view term) const -> std::optional<std::uint32_t> {
     return pisa::binary_search(m_lexicon.begin(), m_lexicon.end(), term);
 }
 
-auto LexiconMap::operator()(std::string const& term) -> std::optional<std::uint32_t> {
+auto LexiconMap::find(std::string const& term) const -> std::optional<std::uint32_t> {
     return pisa::binary_search(m_lexicon.begin(), m_lexicon.end(), term);
+}
+
+auto LexiconMap::operator[](std::uint32_t term_id) const -> std::string_view {
+    return m_lexicon[term_id];
+}
+
+auto LexiconMap::size() const noexcept -> std::size_t {
+    return m_lexicon.size();
 }
 
 }  // namespace pisa

--- a/test/in_memory_index.cpp
+++ b/test/in_memory_index.cpp
@@ -8,7 +8,7 @@ auto VectorCursor::docid() const noexcept -> std::uint32_t {
     return documents[0];
 }
 
-auto VectorCursor::freq() const noexcept -> float {
+auto VectorCursor::freq() const noexcept -> std::uint32_t {
     return frequencies[0];
 }
 

--- a/test/in_memory_index.hpp
+++ b/test/in_memory_index.hpp
@@ -14,7 +14,7 @@ struct VectorCursor {
 
     [[nodiscard]] auto size() const noexcept -> std::size_t;
     [[nodiscard]] auto docid() const noexcept -> std::uint32_t;
-    [[nodiscard]] auto freq() const noexcept -> float;
+    [[nodiscard]] auto freq() const noexcept -> std::uint32_t;
     void next();
     void next_geq(std::uint32_t docid);
 

--- a/test/test_ranked_queries.cpp
+++ b/test/test_ranked_queries.cpp
@@ -96,6 +96,7 @@ class ranked_or_taat_query_acc: public ranked_or_taat_query {
     using ranked_or_taat_query::ranked_or_taat_query;
 
     template <typename CursorRange>
+    PISA_REQUIRES((pisa::concepts::MaxScorePostingCursor<typename std::decay_t<CursorRange>::value_type>))
     void operator()(CursorRange&& cursors, uint64_t max_docid) {
         Acc accumulator(max_docid);
         ranked_or_taat_query::operator()(cursors, max_docid, accumulator);
@@ -108,6 +109,7 @@ class range_query_128: public range_query<T> {
     using range_query<T>::range_query;
 
     template <typename CursorRange>
+    PISA_REQUIRES((pisa::concepts::MaxScorePostingCursor<typename std::decay_t<CursorRange>::value_type>))
     void operator()(CursorRange&& cursors, uint64_t max_docid) {
         range_query<T>::operator()(cursors, max_docid, 128);
     }


### PR DESCRIPTION
This change set contains commits that introduce C++20 concepts for:
* mappings,
* posting lists,
* inverted index.

Concepts are only used when compiled in C++20 mode, ignored otherwise.

Assertions are added to known structures that satisfy these concepts.

Some `require` constraints are also added, most notably for the algorithm execution that expect certain posting lists.

## Rationale

Concepts are introduced for faster constraint checking and explicit interface modeling when templates are used.