### PR TITLE
Verify quantized index after compression

### DIFF
--- a/include/pisa/scorer/quantized.hpp
+++ b/include/pisa/scorer/quantized.hpp
@@ -37,7 +37,9 @@ class QuantizingScorer {
         -> std::function<std::uint32_t(std::uint32_t, std::uint32_t)> {
         return
             [this, scorer = m_scorer->term_scorer(term_id)](std::uint32_t doc, std::uint32_t freq) {
-                return this->m_quantizer(scorer(doc, freq));
+                auto score = scorer(doc, freq);
+                assert(score >= 0.0);
+                return this->m_quantizer(score);
             };
     }
 };

--- a/include/pisa/scorer/quantized.hpp
+++ b/include/pisa/scorer/quantized.hpp
@@ -1,18 +1,44 @@
 #pragma once
 
 #include <algorithm>
-#include <cmath>
 #include <cstdint>
 #include <utility>
 
 #include "index_scorer.hpp"
+#include "linear_quantizer.hpp"
+
 namespace pisa {
 
 template <typename Wand>
 struct quantized: public index_scorer<Wand> {
     using index_scorer<Wand>::index_scorer;
+
     term_scorer_t term_scorer([[maybe_unused]] uint64_t term_id) const {
         return []([[maybe_unused]] uint32_t doc, uint32_t freq) { return freq; };
+    }
+};
+
+/**
+ * Uses internal scorer and quantizer to produce quantized scores.
+ *
+ * This is not inheriting from `index_scorer` because it returns int scores.
+ */
+template <typename Wand>
+class QuantizingScorer {
+  private:
+    std::unique_ptr<index_scorer<Wand>> m_scorer;
+    LinearQuantizer m_quantizer;
+
+  public:
+    QuantizingScorer(std::unique_ptr<index_scorer<Wand>> scorer, LinearQuantizer quantizer)
+        : m_scorer(std::move(scorer)), m_quantizer(quantizer) {}
+
+    [[nodiscard]] auto term_scorer(std::uint64_t term_id) const
+        -> std::function<std::uint32_t(std::uint32_t, std::uint32_t)> {
+        return
+            [this, scorer = m_scorer->term_scorer(term_id)](std::uint32_t doc, std::uint32_t freq) {
+                return this->m_quantizer(scorer(doc, freq));
+            };
     }
 };
 

--- a/test/test_compress.cpp
+++ b/test/test_compress.cpp
@@ -1,0 +1,87 @@
+#define CATCH_CONFIG_MAIN
+#include "catch2/catch.hpp"
+
+#include "pisa/compress.hpp"
+#include "pisa/scorer/scorer.hpp"
+#include "pisa/wand_data.hpp"
+#include "pisa_config.hpp"
+#include "temporary_directory.hpp"
+#include "type_safe.hpp"
+#include "wand_utils.hpp"
+
+TEST_CASE("Compress block index", "[index][compress]") {
+    std::string encoding = GENERATE(
+        "ef",
+        "single",
+        "pefuniform",
+        "pefopt",
+        "block_optpfor",
+        "block_varintg8iu",
+        "block_streamvbyte",
+        "block_maskedvbyte",
+        "block_varintgb",
+        "block_interpolative",
+        "block_qmx",
+        "block_simple8b",
+        "block_simple16",
+        "block_simdbp"
+    );
+    pisa::TemporaryDirectory tmp;
+    pisa::compress(
+        PISA_SOURCE_DIR "/test/test_data/test_collection",
+        std::nullopt,  // no wand
+        encoding,
+        (tmp.path() / encoding).string(),
+        ScorerParams(""),  // no scorer
+        std::nullopt,  // no quantization
+        true  // check=true
+    );
+}
+
+TEST_CASE("Compress quantized block index", "[index][compress]") {
+    auto input = PISA_SOURCE_DIR "/test/test_data/test_collection";
+
+    std::string scorer = GENERATE("bm25");
+    CAPTURE(scorer);
+    auto scorer_params = ScorerParams(scorer);
+
+    pisa::TemporaryDirectory tmp;
+    pisa::create_wand_data(
+        (tmp.path() / "wand").string(),
+        input,
+        pisa::FixedBlock(64),
+        scorer_params,
+        false,
+        false,
+        pisa::Size(8),
+        std::unordered_set<std::size_t>()
+    );
+
+    std::string encoding = GENERATE(
+        "ef",
+        "single",
+        "pefuniform",
+        "pefopt",
+        "block_optpfor",
+        "block_varintg8iu",
+        "block_streamvbyte",
+        "block_maskedvbyte",
+        "block_varintgb",
+        "block_interpolative",
+        "block_qmx",
+        "block_simple8b",
+        "block_simple16",
+        "block_simdbp"
+    );
+    CAPTURE(encoding);
+
+    pisa::compress(
+        input,
+        (tmp.path() / "wand").string(),
+        encoding,
+        (tmp.path() / encoding).string(),
+        scorer_params,
+        pisa::Size(8),
+        true  // check=true
+    );
+}

--- a/test/test_stream_builder.cpp
+++ b/test/test_stream_builder.cpp
@@ -1,18 +1,11 @@
 #define CATCH_CONFIG_MAIN
 
 #include <catch2/catch.hpp>
-#include <functional>
 
-#include "accumulator/lazy_accumulator.hpp"
-#include "cursor/block_max_scored_cursor.hpp"
-#include "cursor/max_scored_cursor.hpp"
-#include "cursor/scored_cursor.hpp"
 #include "index_types.hpp"
 #include "io.hpp"
 #include "pisa_config.hpp"
-#include "query/algorithm.hpp"
 #include "temporary_directory.hpp"
-#include "test_common.hpp"
 
 using namespace pisa;
 


### PR DESCRIPTION
Make the `--check` flag to take effect when compressing an index.

Note that tests for scorers other than BM25 are missing as they are currently failing. It needs further investigation.