### PR TITLE
Add option that restores the ability to perform index compression in memory

### DIFF
--- a/include/pisa/compress.hpp
+++ b/include/pisa/compress.hpp
@@ -15,7 +15,8 @@ void compress(
     std::string const& output_filename,
     ScorerParams const& scorer_params,
     std::optional<Size> quantization_bits,
-    bool check
+    bool check,
+    bool in_memory
 );
 
 }  // namespace pisa

--- a/test/test_compress.cpp
+++ b/test/test_compress.cpp
@@ -26,6 +26,7 @@ TEST_CASE("Compress index", "[index][compress]") {
         "block_simple16",
         "block_simdbp"
     );
+    const bool in_memory = GENERATE(true, false);
     pisa::TemporaryDirectory tmp;
     pisa::compress(
         PISA_SOURCE_DIR "/test/test_data/test_collection",
@@ -35,7 +36,7 @@ TEST_CASE("Compress index", "[index][compress]") {
         ScorerParams(""),  // no scorer
         std::nullopt,  // no quantization
         true,  // check=true
-        GENERATE(true, false)  // in-memory=(true, false)
+        in_memory
     );
 }
 
@@ -75,6 +76,7 @@ TEST_CASE("Compress quantized index", "[index][compress]") {
         "block_simdbp"
     );
     CAPTURE(encoding);
+    const bool in_memory = GENERATE(true, false);
 
     pisa::compress(
         input,
@@ -84,6 +86,6 @@ TEST_CASE("Compress quantized index", "[index][compress]") {
         scorer_params,
         pisa::Size(8),
         true,  // check=true,
-        GENERATE(true, false)  // in-memory=(true, false)
+        in_memory
     );
 }

--- a/test/test_compress.cpp
+++ b/test/test_compress.cpp
@@ -34,7 +34,8 @@ TEST_CASE("Compress index", "[index][compress]") {
         (tmp.path() / encoding).string(),
         ScorerParams(""),  // no scorer
         std::nullopt,  // no quantization
-        true  // check=true
+        true,  // check=true
+        false  // in-memory=false
     );
 }
 
@@ -82,6 +83,7 @@ TEST_CASE("Compress quantized index", "[index][compress]") {
         (tmp.path() / encoding).string(),
         scorer_params,
         pisa::Size(8),
-        true  // check=true
+        true,  // check=true,
+        false  // in-memory=true
     );
 }

--- a/test/test_compress.cpp
+++ b/test/test_compress.cpp
@@ -35,7 +35,7 @@ TEST_CASE("Compress index", "[index][compress]") {
         ScorerParams(""),  // no scorer
         std::nullopt,  // no quantization
         true,  // check=true
-        false  // in-memory=false
+        GENERATE(true, false)  // in-memory=(true, false)
     );
 }
 
@@ -84,6 +84,6 @@ TEST_CASE("Compress quantized index", "[index][compress]") {
         scorer_params,
         pisa::Size(8),
         true,  // check=true,
-        false  // in-memory=true
+        GENERATE(true, false)  // in-memory=(true, false)
     );
 }

--- a/tools/app.hpp
+++ b/tools/app.hpp
@@ -270,11 +270,13 @@ namespace arg {
                 ->required();
             app->add_option("-o,--output", m_output, "Output inverted index")->required();
             app->add_flag("--check", m_check, "Check the correctness of the index");
+            app->add_flag("--in-memory", m_in_memory, "Compress the index in memory, without using an intermediate buffer");
         }
 
         [[nodiscard]] auto input_basename() const -> std::string { return m_input_basename; }
         [[nodiscard]] auto output() const -> std::string { return m_output; }
         [[nodiscard]] auto check() const -> bool { return m_check; }
+        [[nodiscard]] auto in_memory() const -> bool { return m_in_memory; }
 
         /// Transform paths for `shard`.
         void apply_shard(Shard_Id shard) {
@@ -286,6 +288,7 @@ namespace arg {
         std::string m_input_basename{};
         std::string m_output{};
         bool m_check = false;
+        bool m_in_memory = false;
     };
 
     struct CreateWandData {

--- a/tools/compress_inverted_index.cpp
+++ b/tools/compress_inverted_index.cpp
@@ -18,6 +18,7 @@ int main(int argc, char** argv) {
         args.output(),
         args.scorer_params(),
         args.quantization_bits(),
-        args.check()
+        args.check(),
+        args.in_memory()
     );
 }

--- a/tools/shards.cpp
+++ b/tools/shards.cpp
@@ -119,7 +119,8 @@ int main(int argc, char** argv) {
                     shard_args.output(),
                     shard_args.scorer_params(),
                     shard_args.quantization_bits(),
-                    shard_args.check()
+                    shard_args.check(),
+                    shard_args.in_memory()
                 );
             }
             return 0;


### PR DESCRIPTION
This adds the `--in-memory` option to the `compress_inverted_index` command, restoring the in-memory compression and allowing it to avoid using an intermediate buffer.