### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.16.9)
 cmake_policy(SET CMP0074 NEW)
 
 project(PISA CXX C)


### PR DESCRIPTION
Update the `cmake_minimum_required` version to 3.16.9. The submodule `external/benchmark` requires 3.16.3, so we bump the main repo to require the last patch version from 3.16.x.
