### PR TITLE
Set RPATH for install target

### DIFF
--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -70,6 +70,11 @@ jobs:
       working-directory: ${{runner.workspace}}/build
       run: cmake --build . --config Debug -- -j 4
 
+    - name: Install
+      shell: bash
+      working-directory: ${{runner.workspace}}/build
+      run: sudo make install
+
     - name: Test CLI
       shell: bash
       working-directory: ${{runner.workspace}}/build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,6 +85,12 @@ if (UNIX)
      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -ggdb") # Add debug info anyway
    endif()
 
+   # modify RPATH when installing to a non-system directory (e.g. /usr/local).
+   # required to find libtbb with non-system libtbb.
+   list(FIND CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES "${CMAKE_INSTALL_PREFIX}/lib" isSystemDir)
+   if(NOT PISA_SYSTEM_ONETBB AND "${isSystemDir}" STREQUAL "-1")
+      set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
+   endif()
 endif()
 
 find_package(OpenMP)

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -9,7 +9,7 @@ target_compile_options(FastPFor PRIVATE -Wno-cast-align)
 
 # Add CLI11
 if (NOT PISA_SYSTEM_CLI11 AND PISA_BUILD_TOOLS)
-    set(CLI11_TESTING OFF CACHE BOOL "skip trecpp testing")
+    set(CLI11_TESTING OFF CACHE BOOL "skip cli11 testing")
     add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/CLI11 EXCLUDE_FROM_ALL)
 endif()
 
@@ -113,7 +113,7 @@ if (NOT PISA_SYSTEM_ONETBB)
     add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/oneTBB)
 endif()
 
-if (PISA_ENABLE_TESTING AND NOT PISA_SYSTEM_GOOGLE_BENCHMARK)
+if (PISA_ENABLE_BENCHMARKING AND NOT PISA_SYSTEM_GOOGLE_BENCHMARK)
     set(BENCHMARK_ENABLE_GTEST_TESTS OFF CACHE BOOL "skip Google Benchmark testing")
     set(BENCHMARK_ENABLE_TESTING OFF CACHE BOOL "skip Google Benchmark testing")
     set(BENCHMARK_ENABLE_WERROR OFF CACHE BOOL "disable -Werror")

--- a/test/cli/setup.sh
+++ b/test/cli/setup.sh
@@ -3,8 +3,10 @@
 # This script should be executed within the build directory that is directly
 # in the project directory, e.g., /path/to/pisa/build
 
-PISA_BIN="./bin"
-export PATH="$PISA_BIN:$PATH"
+command -v compress_inverted_index >/dev/null 2>&1 || {
+    echo >&2 "tools not available in default path"
+    exit 1
+}
 
 test_dir=${TEST_DIR:-../test}
 

--- a/test/cli/test_count_postings.sh
+++ b/test/cli/test_count_postings.sh
@@ -2,8 +2,6 @@
 
 set +x
 
-PISA_BIN="bin"
-export PATH="$PISA_BIN:$PATH"
 DIR=$(dirname "$0")
 
 @test "Extract posting counts" {

--- a/test/cli/test_taily_stats.sh
+++ b/test/cli/test_taily_stats.sh
@@ -2,8 +2,6 @@
 
 set +x
 
-PISA_BIN="bin"
-export PATH="$PISA_BIN:$PATH"
 DIR=$(dirname "$0")
 
 echo_int () {

--- a/test/cli/test_wand_data.sh
+++ b/test/cli/test_wand_data.sh
@@ -2,9 +2,6 @@
 
 set +x
 
-PISA_BIN="bin"
-export PATH="$PISA_BIN:$PATH"
-
 queries=$(cat <<HERE
 301:International Organized Crime
 302:Poliomyelitis and Post-Polio


### PR DESCRIPTION
Incremental fix for #242, set the runtime path so that the cli tools can find libtbb when building PISA with the libtbb submodule which is the default option.

- Set RPATH
- Add install step to the cli test build
- Typo fix for benchmark option
