### PR TITLE
Remove GSL in favor of stdlib

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,7 +127,6 @@ target_link_libraries(pisa
         Boost::boost
         mio
         mio_base
-        GSL
         spdlog
         fmt::fmt
         range-v3

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -47,9 +47,6 @@ add_library(simdcomp STATIC ${CMAKE_CURRENT_SOURCE_DIR}/simdcomp/src/simdbitpack
                             ${CMAKE_CURRENT_SOURCE_DIR}/simdcomp/src/simdcomputil.c
 )
 
-# Add GSL
-add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/GSL EXCLUDE_FROM_ALL)
-
 # Add Boost
 if (NOT PISA_SYSTEM_BOOST)
     add_subdirectory(boost-cmake)

--- a/include/pisa/codec/block_codec_registry.hpp
+++ b/include/pisa/codec/block_codec_registry.hpp
@@ -1,10 +1,11 @@
 #pragma once
 
+#include <algorithm>
 #include <memory>
+#include <span>
 #include <string_view>
 
 #include <fmt/format.h>
-#include <gsl/span>
 
 #include "codec/block_codec.hpp"
 
@@ -44,6 +45,6 @@ struct BlockCodecRegistry {
 /**
  * Lists the names of all known block codecs.
  */
-[[nodiscard]] constexpr auto get_block_codec_names() -> gsl::span<std::string_view const>;
+[[nodiscard]] constexpr auto get_block_codec_names() -> std::span<std::string_view const>;
 
 }  // namespace pisa

--- a/include/pisa/concepts/container.hpp
+++ b/include/pisa/concepts/container.hpp
@@ -1,4 +1,3 @@
-
 // Copyright 2024 PISA developers
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/include/pisa/invert.hpp
+++ b/include/pisa/invert.hpp
@@ -1,10 +1,10 @@
 #pragma once
 
 #include <optional>
+#include <span>
 #include <thread>
 #include <vector>
 
-#include <gsl/span>
 #include <range/v3/view/iota.hpp>
 #include <tbb/blocked_range.h>
 
@@ -16,7 +16,7 @@ namespace pisa { namespace invert {
     using PostingIterator = typename std::vector<Posting>::iterator;
     using Documents = std::unordered_map<Term_Id, std::vector<Document_Id>>;
     using Frequencies = std::unordered_map<Term_Id, std::vector<Frequency>>;
-    using DocumentRange = gsl::span<gsl::span<Term_Id const>>;
+    using DocumentRange = std::span<std::span<Term_Id const>>;
 
     /// Inverted index abstraction used internally in the inverting process.
     ///
@@ -42,7 +42,7 @@ namespace pisa { namespace invert {
 
     /// A single slice view over a chunk of a forward index.
     struct ForwardIndexSlice {
-        gsl::span<gsl::span<Term_Id const>> documents;
+        std::span<std::span<Term_Id const>> documents;
         ranges::iota_view<Document_Id, Document_Id> document_ids;
     };
 

--- a/include/pisa/io.hpp
+++ b/include/pisa/io.hpp
@@ -3,10 +3,9 @@
 #include <exception>
 #include <filesystem>
 #include <iostream>
+#include <span>
 #include <string>
 #include <vector>
-
-#include <gsl/span>
 
 namespace pisa::io {
 
@@ -45,6 +44,6 @@ void for_each_line(std::istream& is, Function fn) {
 [[nodiscard]] auto load_data(std::string const& data_file) -> std::vector<char>;
 
 /// Writes bytes to a file.
-void write_data(std::string const& data_file, gsl::span<std::byte const> bytes);
+void write_data(std::string const& data_file, std::span<std::byte const> bytes);
 
 }  // namespace pisa::io

--- a/include/pisa/linear_quantizer.hpp
+++ b/include/pisa/linear_quantizer.hpp
@@ -3,7 +3,6 @@
 #include <cstdint>
 
 #include <fmt/format.h>
-#include <gsl/gsl_assert>
 
 namespace pisa {
 

--- a/include/pisa/memory_source.hpp
+++ b/include/pisa/memory_source.hpp
@@ -2,9 +2,9 @@
 
 #include <filesystem>
 #include <memory>
+#include <span>
 #include <vector>
 
-#include <gsl/span>
 #include <mio/mmap.hpp>
 
 namespace pisa {
@@ -29,7 +29,7 @@ class MemorySource {
     /// Constructs a memory source from a vector.
     ///
     /// NOTE: This is non-owning source, so tread carefully!
-    [[nodiscard]] static auto from_span(gsl::span<char> span) -> MemorySource;
+    [[nodiscard]] static auto from_span(std::span<char> span) -> MemorySource;
 
     /// Constructs a memory source using a memory mapped file.
     ///
@@ -65,13 +65,13 @@ class MemorySource {
     [[nodiscard]] auto size() const -> size_type;
 
     /// Full span over memory.
-    [[nodiscard]] auto span() const -> gsl::span<value_type const>;
+    [[nodiscard]] auto span() const -> std::span<value_type const>;
 
     /// Subspan of memory.
     ///
     /// \throws std::out_of_range   if offset + size is out of bounds
-    [[nodiscard]] auto subspan(size_type offset, size_type size = gsl::dynamic_extent) const
-        -> gsl::span<value_type const>;
+    [[nodiscard]] auto subspan(size_type offset, size_type size = std::dynamic_extent) const
+        -> std::span<value_type const>;
 
     /// Type erasure interface. Any type implementing it are supported as memory source.
     struct Interface {

--- a/include/pisa/sharding.hpp
+++ b/include/pisa/sharding.hpp
@@ -1,11 +1,10 @@
 #pragma once
 
 #include <optional>
+#include <span>
 
-#include <gsl/span>
 #include <spdlog/spdlog.h>
 
-#include "io.hpp"
 #include "type_safe.hpp"
 #include "vec_map.hpp"
 
@@ -18,10 +17,10 @@ format_shard(std::string_view basename, Shard_Id shard, std::string_view suffix 
 
 auto resolve_shards(std::string_view basename, std::string_view suffix = {}) -> std::vector<Shard_Id>;
 
-auto mapping_from_files(std::istream* full_titles, gsl::span<std::istream*> shard_titles)
+auto mapping_from_files(std::istream* full_titles, std::span<std::istream*> shard_titles)
     -> VecMap<Document_Id, Shard_Id>;
 
-auto mapping_from_files(std::string const& full_titles, gsl::span<std::string const> shard_titles)
+auto mapping_from_files(std::string const& full_titles, std::span<std::string const> shard_titles)
     -> VecMap<Document_Id, Shard_Id>;
 
 auto create_random_mapping(

--- a/include/pisa/span.hpp
+++ b/include/pisa/span.hpp
@@ -1,0 +1,56 @@
+// Copyright 2024 PISA developers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <span>
+#include <stdexcept>
+
+namespace pisa {
+
+/**
+ * Element access with bound checking.
+ *
+ * The method `at()` is not available in C++20, therefore we use this helper function whenever we
+ * want checked access.
+ */
+template <typename T>
+[[nodiscard]] constexpr auto at(std::span<T> const& span, typename std::span<T>::size_type pos)
+    -> std::span<T>::reference {
+    if (pos >= span.size()) {
+        throw std::out_of_range("out of range access to span");
+    }
+    return span[pos];
+}
+
+}  // namespace pisa
+
+namespace std {
+
+template <typename T>
+[[nodiscard]] auto operator==(std::span<T> const& lhs, std::span<T> const& rhs) -> bool {
+    if (lhs.size() != rhs.size()) {
+        return false;
+    }
+    auto lit = lhs.begin();
+    auto rit = rhs.begin();
+    while (lit != lhs.end()) {
+        if (*lit++ != *rit++) {
+            return false;
+        }
+    }
+    return true;
+}
+
+}  // namespace std

--- a/include/pisa/taily_stats.hpp
+++ b/include/pisa/taily_stats.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
-#include <gsl/span>
+#include <span>
+
 #include <mio/mmap.hpp>
 #include <taily.hpp>
 
@@ -54,10 +55,9 @@ class TailyStats {
     }
 
     [[nodiscard]] PISA_ALWAYSINLINE auto bytes(std::size_t start, std::size_t size) const
-        -> gsl::span<char const> {
-        try {
-            return m_source.subspan(start, size);
-        } catch (std::out_of_range const&) {
+        -> std::span<char const> {
+        if (start > m_source.size()
+            || (size != std::dynamic_extent && start + size > m_source.size())) {
             throw std::out_of_range(fmt::format(
                 "Tried to read bytes {}-{} but memory source is of size {}",
                 start,
@@ -65,6 +65,7 @@ class TailyStats {
                 m_source.size()
             ));
         }
+        return m_source.subspan(start, size);
     }
 
     MemorySource m_source;
@@ -99,7 +100,7 @@ template <typename Scorer>
 }
 
 void write_feature_stats(
-    gsl::span<taily::Feature_Statistics> stats, std::size_t num_documents, std::string const& output_path
+    std::span<taily::Feature_Statistics> stats, std::size_t num_documents, std::string const& output_path
 ) {
     std::ofstream ofs(output_path);
     ofs.write(reinterpret_cast<const char*>(&num_documents), sizeof(num_documents));

--- a/include/pisa/util/inverted_index_utils.hpp
+++ b/include/pisa/util/inverted_index_utils.hpp
@@ -2,9 +2,8 @@
 
 #include <filesystem>
 #include <fstream>
+#include <span>
 #include <unordered_set>
-
-#include <gsl/span>
 
 #include "binary_freq_collection.hpp"
 #include "util/progress.hpp"
@@ -12,7 +11,7 @@
 namespace pisa {
 
 template <typename T>
-std::ostream& write_sequence(std::ostream& os, gsl::span<T> sequence) {
+std::ostream& write_sequence(std::ostream& os, std::span<T> sequence) {
     auto length = static_cast<uint32_t>(sequence.size());
     os.write(reinterpret_cast<const char*>(&length), sizeof(length));
     os.write(reinterpret_cast<const char*>(sequence.data()), length * sizeof(T));
@@ -47,7 +46,7 @@ void sample_inverted_index(
     std::ofstream fos(output_basename + ".freqs");
 
     auto document_count = static_cast<std::uint32_t>(input.num_docs());
-    write_sequence(dos, gsl::make_span<std::uint32_t const>(&document_count, 1));
+    write_sequence(dos, std::span<std::uint32_t const>(&document_count, 1));
     pisa::progress progress("Sampling inverted index", input.size());
     size_t term = 0;
     for (auto const& plist: input) {
@@ -68,8 +67,8 @@ void sample_inverted_index(
             sampled_freqs.push_back(plist.freqs[index]);
         }
 
-        write_sequence(dos, gsl::span<std::uint32_t const>(sampled_docs));
-        write_sequence(fos, gsl::span<std::uint32_t const>(sampled_freqs));
+        write_sequence(dos, std::span<std::uint32_t const>(sampled_docs));
+        write_sequence(fos, std::span<std::uint32_t const>(sampled_freqs));
         term += 1;
         progress.update(1);
     }

--- a/src/codec/block_codec_registry.cpp
+++ b/src/codec/block_codec_registry.cpp
@@ -1,10 +1,10 @@
 #include "codec/block_codec_registry.hpp"
 
 #include <array>
+#include <span>
 #include <string_view>
 
 #include <fmt/format.h>
-#include <gsl/span>
 
 #include "codec/block_codec.hpp"
 #include "codec/interpolative.hpp"
@@ -36,8 +36,8 @@ auto get_block_codec(std::string_view name) -> BlockCodecPtr {
     return BlockCodecs::get(name);
 }
 
-constexpr auto get_block_codec_names() -> gsl::span<std::string_view const> {
-    return gsl::make_span<std::string_view const>(&BlockCodecs::names[0], BlockCodecs::count());
+constexpr auto get_block_codec_names() -> std::span<std::string_view const> {
+    return std::span<std::string_view const>(&BlockCodecs::names[0], BlockCodecs::count());
 }
 
 }  // namespace pisa

--- a/src/forward_index_builder.cpp
+++ b/src/forward_index_builder.cpp
@@ -3,7 +3,6 @@
 #include <map>
 #include <sstream>
 
-#include <gsl/gsl_assert>
 #include <range/v3/view/iota.hpp>
 #include <spdlog/fmt/ostr.h>
 #include <spdlog/spdlog.h>
@@ -93,7 +92,9 @@ auto Forward_Index_Builder::collect_terms(std::string const& basename, std::ptrd
     std::stack<Term_Span> spans;
     std::vector<std::string> terms;
     auto merge_spans = [&](Term_Span lhs, Term_Span rhs) {
-        Expects(lhs.last == rhs.first);
+        if (lhs.last != rhs.first) {
+            throw std::invalid_argument("first and last elements are not equal");
+        }
         auto first = std::next(terms.begin(), lhs.first);
         auto mid = std::next(terms.begin(), lhs.last);
         auto last = std::next(terms.begin(), rhs.last);

--- a/src/invert.cpp
+++ b/src/invert.cpp
@@ -79,9 +79,9 @@ namespace pisa { namespace invert {
             document_sizes.begin(),
             [](auto const& terms) { return terms.size(); }
         );
-        gsl::index batch_size = (documents.size() + threads - 1) / threads;
+        std::size_t batch_size = (documents.size() + threads - 1) / threads;
         std::vector<ForwardIndexSlice> batches;
-        for (gsl::index first_idx_in_batch = 0; first_idx_in_batch < documents.size();
+        for (std::size_t first_idx_in_batch = 0; first_idx_in_batch < documents.size();
              first_idx_in_batch += batch_size) {
             auto last_idx_in_batch = std::min(first_idx_in_batch + batch_size, documents.size());
             auto first_document_in_batch = first_document_id + first_idx_in_batch;
@@ -116,19 +116,19 @@ namespace pisa { namespace invert {
         std::ofstream fstream(basename + ".freqs");
         std::ofstream sstream(basename + ".sizes");
         std::uint32_t count = index.document_sizes.size();
-        write_sequence(dstream, gsl::make_span<uint32_t const>(&count, 1));
+        write_sequence(dstream, std::span<uint32_t const>(&count, 1));
         for (auto term: ranges::views::iota(Term_Id(0), Term_Id(term_count))) {
             if (auto pos = index.documents.find(term); pos != index.documents.end()) {
                 auto const& documents = pos->second;
                 auto const& frequencies = index.frequencies.at(term);
-                write_sequence(dstream, gsl::span<Document_Id const>(documents));
-                write_sequence(fstream, gsl::span<Frequency const>(frequencies));
+                write_sequence(dstream, std::span<Document_Id const>(documents));
+                write_sequence(fstream, std::span<Frequency const>(frequencies));
             } else {
-                write_sequence(dstream, gsl::span<Document_Id const>());
-                write_sequence(fstream, gsl::span<Frequency const>());
+                write_sequence(dstream, std::span<Document_Id const>());
+                write_sequence(fstream, std::span<Frequency const>());
             }
         }
-        write_sequence(sstream, gsl::span<uint32_t const>(index.document_sizes));
+        write_sequence(sstream, std::span<uint32_t const>(index.document_sizes));
     }
 
     [[nodiscard]] auto build_batches(
@@ -139,7 +139,7 @@ namespace pisa { namespace invert {
         auto doc_iter = ++coll.begin();
         uint32_t documents_processed = 0;
         while (doc_iter != coll.end()) {
-            std::vector<gsl::span<Term_Id const>> documents;
+            std::vector<std::span<Term_Id const>> documents;
             for (; doc_iter != coll.end() && documents.size() < params.batch_size; ++doc_iter) {
                 auto document_sequence = *doc_iter;
                 documents.emplace_back(
@@ -173,7 +173,7 @@ namespace pisa { namespace invert {
         }
 
         std::ofstream sos(output_basename + ".sizes");
-        write_sequence(sos, gsl::span<uint32_t const>(document_sizes));
+        write_sequence(sos, std::span<uint32_t const>(document_sizes));
 
         std::vector<binary_collection::const_iterator> doc_iterators;
         std::vector<binary_collection::const_iterator> freq_iterators;
@@ -193,7 +193,7 @@ namespace pisa { namespace invert {
         std::ofstream dos(output_basename + ".docs");
         std::ofstream fos(output_basename + ".freqs");
         auto document_count = static_cast<uint32_t>(document_sizes.size());
-        write_sequence(dos, gsl::make_span<uint32_t const>(&document_count, 1));
+        write_sequence(dos, std::span<uint32_t const>(&document_count, 1));
         size_t postings_count = 0;
         for (auto term_id: ranges::views::iota(uint32_t(0), term_count)) {
             std::vector<uint32_t> dlist;
@@ -225,8 +225,8 @@ namespace pisa { namespace invert {
                 throw std::runtime_error(msg);
             }
             postings_count += dlist.size();
-            write_sequence(dos, gsl::span<uint32_t const>(dlist));
-            write_sequence(fos, gsl::span<uint32_t const>(flist));
+            write_sequence(dos, std::span<uint32_t const>(dlist));
+            write_sequence(fos, std::span<uint32_t const>(flist));
         }
 
         spdlog::info("Number of terms: {}", term_count);

--- a/src/io.cpp
+++ b/src/io.cpp
@@ -44,7 +44,7 @@ auto load_data(std::string const& data_file) -> std::vector<char> {
     return data;
 }
 
-void write_data(std::string const& data_file, gsl::span<std::byte const> bytes) {
+void write_data(std::string const& data_file, std::span<std::byte const> bytes) {
     std::ofstream os(data_file);
     os.write(reinterpret_cast<char const*>(bytes.data()), bytes.size());
 }

--- a/src/linear_quantizer.cpp
+++ b/src/linear_quantizer.cpp
@@ -1,5 +1,7 @@
 #include <cmath>
+#include <stdexcept>
 
+#include "fmt/core.h"
 #include "linear_quantizer.hpp"
 
 namespace pisa {
@@ -19,7 +21,11 @@ LinearQuantizer::LinearQuantizer(float max, std::uint8_t bits)
 }
 
 auto LinearQuantizer::operator()(float value) const -> std::uint32_t {
-    Expects(0 <= value && value <= m_max);
+    if (value < 0 || value > m_max) {
+        throw std::invalid_argument(
+            fmt::format("quantized value must be between 0 and {} but {} given", m_max, value)
+        );
+    }
     return std::round(value * m_scale) + 1;
 }
 

--- a/src/memory_source.cpp
+++ b/src/memory_source.cpp
@@ -12,7 +12,7 @@ auto MemorySource::from_vector(std::vector<char> vec) -> MemorySource {
     return MemorySource(std::move(vec));
 }
 
-auto MemorySource::from_span(gsl::span<char> span) -> MemorySource {
+auto MemorySource::from_span(std::span<char> span) -> MemorySource {
     return MemorySource(span);
 }
 
@@ -59,17 +59,17 @@ auto MemorySource::size() const -> size_type {
     return m_source->size();
 }
 
-auto MemorySource::span() const -> gsl::span<value_type const> {
+auto MemorySource::span() const -> std::span<value_type const> {
     if (m_source == nullptr) {
-        return gsl::span<value_type const>();
+        return std::span<value_type const>();
     }
-    return gsl::span<value_type const>(begin(), size());
+    return std::span<value_type const>(begin(), size());
 }
 
-auto MemorySource::subspan(size_type offset, size_type size) const -> gsl::span<value_type const> {
+auto MemorySource::subspan(size_type offset, size_type size) const -> std::span<value_type const> {
     if (m_source == nullptr) {
-        if (offset == 0 && (size == 0 || size == gsl::dynamic_extent)) {
-            return gsl::span<value_type const>();
+        if (offset == 0 && (size == 0 || size == std::dynamic_extent)) {
+            return std::span<value_type const>();
         }
         throw std::out_of_range("Subspan out of bounds");
     }

--- a/src/sharding.cpp
+++ b/src/sharding.cpp
@@ -15,6 +15,7 @@
 #include "binary_collection.hpp"
 #include "payload_vector.hpp"
 #include "util/util.hpp"
+#include "io.hpp"
 
 namespace pisa {
 
@@ -52,7 +53,7 @@ auto resolve_shards(std::string_view basename, std::string_view suffix) -> std::
     return shards;
 }
 
-auto mapping_from_files(std::istream* full_titles, gsl::span<std::istream*> shard_titles)
+auto mapping_from_files(std::istream* full_titles, std::span<std::istream*> shard_titles)
     -> VecMap<Document_Id, Shard_Id> {
     std::unordered_map<std::string, Shard_Id> map;
     auto shard_id = Shard_Id(0);
@@ -85,7 +86,7 @@ auto mapping_from_files(std::istream* full_titles, gsl::span<std::istream*> shar
     return result;
 }
 
-auto mapping_from_files(std::string const& full_titles, gsl::span<std::string const> shard_titles)
+auto mapping_from_files(std::string const& full_titles, std::span<std::string const> shard_titles)
     -> VecMap<Document_Id, Shard_Id> {
     std::ifstream fis(full_titles);
     std::vector<std::unique_ptr<std::istream>> shard_is;
@@ -97,7 +98,7 @@ auto mapping_from_files(std::string const& full_titles, gsl::span<std::string co
     }
     auto title_files = shard_is | ranges::views::transform([](auto& is) { return is.get(); })
         | ranges::to<std::vector>();
-    return mapping_from_files(&fis, gsl::make_span(title_files));
+    return mapping_from_files(&fis, std::span(title_files));
 }
 
 auto create_random_mapping(int document_count, int shard_count, std::optional<std::uint64_t> seed)

--- a/test/in_memory_index.cpp
+++ b/test/in_memory_index.cpp
@@ -1,3 +1,5 @@
+#include <span>
+
 #include "in_memory_index.hpp"
 
 auto VectorCursor::size() const noexcept -> std::size_t {
@@ -31,7 +33,7 @@ void VectorCursor::next_geq(std::uint32_t docid) {
 
 void VectorCursor::try_finish() {
     if (documents.empty()) {
-        documents = gsl::make_span(sentinel_document);
+        documents = std::span(sentinel_document);
     }
 }
 
@@ -42,10 +44,7 @@ auto InMemoryIndex::operator[](std::uint32_t term_id) const -> VectorCursor {
         );
     }
     return {
-        gsl::make_span(documents[term_id]),
-        gsl::make_span(frequencies[term_id]),
-        num_documents,
-        {num_documents}
+        std::span(documents[term_id]), std::span(frequencies[term_id]), num_documents, {num_documents}
     };
 }
 

--- a/test/in_memory_index.hpp
+++ b/test/in_memory_index.hpp
@@ -1,13 +1,13 @@
 #pragma once
 
+#include <span>
 #include <vector>
 
 #include <fmt/format.h>
-#include <gsl/span>
 
 struct VectorCursor {
-    gsl::span<std::uint32_t const> documents;
-    gsl::span<std::uint32_t const> frequencies;
+    std::span<std::uint32_t const> documents;
+    std::span<std::uint32_t const> frequencies;
     std::uint32_t max_docid;
 
     std::array<std::uint32_t, 1> sentinel_document;

--- a/test/test_forward_index_builder.cpp
+++ b/test/test_forward_index_builder.cpp
@@ -2,10 +2,10 @@
 
 #include <algorithm>
 #include <filesystem>
+#include <span>
 #include <string>
 
 #include <catch2/catch.hpp>
-#include <gsl/span>
 
 #include "binary_collection.hpp"
 #include "filesystem.hpp"
@@ -72,16 +72,16 @@ TEST_CASE("Write header", "[parsing][forward_index]") {
 }
 
 template <typename T>
-void write_lines(std::ostream& os, gsl::span<T>&& elements) {
+void write_lines(std::ostream& os, std::span<T>&& elements) {
     for (auto const& element: elements) {
         os << element << '\n';
     }
 }
 
 template <typename T>
-void write_lines(std::string const& filename, gsl::span<T>&& elements) {
+void write_lines(std::string const& filename, std::span<T>&& elements) {
     std::ofstream os(filename);
-    write_lines<T>(os, std::forward<gsl::span<T>>(elements));
+    write_lines<T>(os, std::forward<std::span<T>>(elements));
 }
 
 TEST_CASE("Build forward index batch", "[parsing][forward_index]") {
@@ -146,8 +146,8 @@ void write_batch(
 ) {
     std::string document_file = basename + ".documents";
     std::string term_file = basename + ".terms";
-    write_lines(document_file, gsl::make_span(documents));
-    write_lines(term_file, gsl::make_span(terms));
+    write_lines(document_file, std::span(documents));
+    write_lines(term_file, std::span(terms));
     std::ofstream os(basename);
     Forward_Index_Builder::write_header(os, collection.size());
     for (auto const& seq: collection) {

--- a/test/test_intersection.cpp
+++ b/test/test_intersection.cpp
@@ -2,9 +2,7 @@
 #include "catch2/catch.hpp"
 
 #include <fmt/format.h>
-#include <gsl/span>
 
-#include "cursor/scored_cursor.hpp"
 #include "in_memory_index.hpp"
 #include "intersection.hpp"
 
@@ -40,7 +38,7 @@ TEST_CASE("Vector cursor", "[intersection][unit]") {
     std::vector<std::uint32_t> documents{0, 3, 5, 6, 87, 111};
     std::vector<std::uint32_t> frequencies{1, 4, 6, 7, 88, 112};
 
-    auto cursor = VectorCursor{gsl::make_span(documents), gsl::make_span(frequencies), 200, {200}};
+    auto cursor = VectorCursor{std::span(documents), std::span(frequencies), 200, {200}};
 
     REQUIRE(cursor.size() == 6);
 
@@ -74,7 +72,7 @@ TEST_CASE("Vector cursor", "[intersection][unit]") {
     REQUIRE(cursor.docid() == 200);
 
     // NEXTGEQ
-    cursor = VectorCursor{gsl::make_span(documents), gsl::make_span(frequencies), 200, {200}};
+    cursor = VectorCursor{std::span(documents), std::span(frequencies), 200, {200}};
 
     REQUIRE(cursor.docid() == 0);
     REQUIRE(cursor.freq() == 1);

--- a/test/test_invert.cpp
+++ b/test/test_invert.cpp
@@ -2,16 +2,15 @@
 #include "catch2/catch.hpp"
 
 #include <cstdio>
+#include <span>
 #include <string>
 
-#include <gsl/span>
+#include <mio/mmap.hpp>
 #include <range/v3/view/iota.hpp>
 
-#include "binary_collection.hpp"
 #include "filesystem.hpp"
 #include "invert.hpp"
 #include "payload_vector.hpp"
-#include "pisa_config.hpp"
 #include "temporary_directory.hpp"
 
 using namespace pisa;
@@ -19,9 +18,7 @@ using namespace pisa::literals;
 
 TEST_CASE("Map sequence of document terms to sequence of postings", "[invert][unit]") {
     std::vector<std::vector<Term_Id>> documents = {{0_t, 1_t, 2_t, 3_t}, {1_t, 2_t, 3_t, 8_t}};
-    std::vector<gsl::span<Term_Id const>> spans = {
-        gsl::make_span(documents[0]), gsl::make_span(documents[1])
-    };
+    std::vector<std::span<Term_Id const>> spans = {std::span(documents[0]), std::span(documents[1])};
 
     auto postings =
         invert::map_to_postings(invert::ForwardIndexSlice{spans, ranges::views::iota(0_d, 2_d)});
@@ -208,12 +205,12 @@ TEST_CASE("Invert a range of documents from a collection", "[invert][unit]") {
         /* Doc 4 */ {8_t, 6_t, 9_t, 6_t, 6_t, 5_t, 4_t, 3_t, 1_t, 0_t, 6_t}
     };
 
-    std::vector<gsl::span<Term_Id const>> document_range;
+    std::vector<std::span<Term_Id const>> document_range;
     std::transform(
         collection.begin(),
         collection.end(),
         std::back_inserter(document_range),
-        [](auto const& vec) { return gsl::span<Term_Id const>(vec); }
+        [](auto const& vec) { return std::span<Term_Id const>(vec); }
     );
     size_t threads = 1;
 

--- a/test/test_partition_fwd_index.cpp
+++ b/test/test_partition_fwd_index.cpp
@@ -4,10 +4,10 @@
 #include <algorithm>
 #include <cstdio>
 #include <iostream>
+#include <span>
 #include <string>
 
 #include <fmt/ostream.h>
-#include <gsl/span>
 #include <range/v3/action/transform.hpp>
 #include <range/v3/algorithm/stable_sort.hpp>
 #include <range/v3/range/conversion.hpp>
@@ -19,6 +19,7 @@
 #include "binary_collection.hpp"
 #include "forward_index_builder.hpp"
 #include "invert.hpp"
+#include "io.hpp"
 #include "payload_vector.hpp"
 #include "pisa_config.hpp"
 #include "sharding.hpp"
@@ -78,7 +79,7 @@ TEST_CASE("mapping_from_files", "[invert][unit]") {
     auto stream_pointers = ranges::views::transform(shards, [](auto const& s) { return s.get(); })
         | ranges::to<std::vector>();
     REQUIRE(
-        mapping_from_files(&full, gsl::span<std::istream*>(stream_pointers)).as_vector()
+        mapping_from_files(&full, std::span<std::istream*>(stream_pointers)).as_vector()
         == std::vector<Shard_Id>{0_s, 0_s, 0_s, 1_s, 1_s, 0_s, 2_s, 2_s, 2_s, 2_s, 2_s, 2_s}
     );
 }

--- a/test/test_span.cpp
+++ b/test/test_span.cpp
@@ -1,0 +1,27 @@
+#define CATCH_CONFIG_MAIN
+#include "catch2/catch.hpp"
+
+#include "span.hpp"
+
+TEST_CASE("pisa::at", "[span]") {
+    std::vector<int> vec{0, 1, 2, 3};
+    auto span = std::span<int>{vec.data(), vec.size()};
+    REQUIRE(pisa::at(span, 0) == 0);
+    REQUIRE(pisa::at(span, 1) == 1);
+    REQUIRE(pisa::at(span, 2) == 2);
+    REQUIRE(pisa::at(span, 3) == 3);
+    REQUIRE_THROWS_AS(pisa::at(span, 4), std::out_of_range);
+}
+
+TEST_CASE("operator== for spans", "[span]") {
+    std::vector<int> vec1{0, 1, 2, 3};
+    auto span1 = std::span<int>(vec1.data(), vec1.size());
+    std::vector<int> vec2{0, 1, 2, 3};
+    auto span2 = std::span<int>(vec2.data(), vec2.size());
+    std::vector<int> vec3{0, 1, 2, -1};
+    auto span3 = std::span<int>(vec3.data(), vec3.size());
+    REQUIRE(span1 == span2);
+    REQUIRE(span1 != span3);
+    REQUIRE(span2 != span3);
+    REQUIRE(span1 == std::span<int>(vec1.data(), vec1.size()));
+}

--- a/test/test_taily_stats.cpp
+++ b/test/test_taily_stats.cpp
@@ -1,12 +1,11 @@
-#include "type_safe.hpp"
-#include <taily.hpp>
 #define CATCH_CONFIG_MAIN
 #include "catch2/catch.hpp"
 
 #include <array>
+#include <span>
 
 #include <boost/interprocess/streams/bufferstream.hpp>
-#include <gsl/span>
+#include <taily.hpp>
 
 #include "binary_freq_collection.hpp"
 #include "io.hpp"
@@ -15,6 +14,7 @@
 #include "scorer/scorer.hpp"
 #include "taily_stats.hpp"
 #include "temporary_directory.hpp"
+#include "type_safe.hpp"
 #include "wand_data.hpp"
 #include "wand_data_raw.hpp"
 
@@ -23,7 +23,7 @@ using taily::Feature_Statistics;
 void write_documents(std::filesystem::path const& path) {
     pisa::io::write_data(
         path.string(),
-        gsl::span<std::byte const>(std::array<std::byte, 44>{
+        std::span<std::byte const>(std::array<std::byte, 44>{
             std::byte{1}, std::byte{0}, std::byte{0}, std::byte{0},
             std::byte{6}, std::byte{0}, std::byte{0}, std::byte{0},  //< #docs
             std::byte{2}, std::byte{0}, std::byte{0}, std::byte{0},  //< term 0
@@ -42,7 +42,7 @@ void write_documents(std::filesystem::path const& path) {
 void write_frequencies(std::filesystem::path const& path) {
     pisa::io::write_data(
         path.string(),
-        gsl::span<std::byte const>(std::array<std::byte, 36>{
+        std::span<std::byte const>(std::array<std::byte, 36>{
             std::byte{2}, std::byte{0}, std::byte{0}, std::byte{0},  //< term 0
             std::byte{1}, std::byte{0}, std::byte{0}, std::byte{0},  //< term 0
             std::byte{1}, std::byte{0}, std::byte{0}, std::byte{0},  //< term 0
@@ -59,7 +59,7 @@ void write_frequencies(std::filesystem::path const& path) {
 void write_sizes(std::filesystem::path const& path) {
     pisa::io::write_data(
         path.string(),
-        gsl::span<std::byte const>(std::array<std::byte, 28>{
+        std::span<std::byte const>(std::array<std::byte, 28>{
             std::byte{5}, std::byte{0}, std::byte{0}, std::byte{0},  //
             std::byte{1}, std::byte{0}, std::byte{0}, std::byte{0},  //
             std::byte{1}, std::byte{0}, std::byte{0}, std::byte{0},  //

--- a/test/test_tokenizer.cpp
+++ b/test/test_tokenizer.cpp
@@ -1,10 +1,10 @@
 #define CATCH_CONFIG_MAIN
 
-#include <catch2/catch.hpp>
+#include <span>
 
 #include <boost/iterator/filter_iterator.hpp>
 #include <boost/spirit/include/lex_lexertl.hpp>
-#include <gsl/span>
+#include <catch2/catch.hpp>
 
 #include "payload_vector.hpp"
 #include "query.hpp"
@@ -85,7 +85,7 @@ TEST_CASE("Parse query terms to ids") {
     pisa::TemporaryDirectory tmpdir;
     auto lexfile = tmpdir.path() / "lex";
     encode_payload_vector(
-        gsl::make_span(std::vector<std::string>{"lol", "obama", "term2", "tree", "usa"})
+        std::span<std::string const>(std::vector<std::string>{"lol", "obama", "term2", "tree", "usa"})
     )
         .to_file(lexfile.string());
 

--- a/tools/invert.cpp
+++ b/tools/invert.cpp
@@ -1,17 +1,9 @@
-#include <algorithm>
-#include <thread>
-#include <vector>
-
-#include "CLI/CLI.hpp"
-#include "gsl/span"
 #include "spdlog/spdlog.h"
 #include "tbb/global_control.h"
 #include "tbb/task_group.h"
 
 #include "app.hpp"
-#include "binary_collection.hpp"
 #include "invert.hpp"
-#include "util/util.hpp"
 
 int main(int argc, char** argv) {
     CLI::App app{"Constructs an inverted index from a forward index."};

--- a/tools/partition_fwd_index.cpp
+++ b/tools/partition_fwd_index.cpp
@@ -1,13 +1,11 @@
-#include <algorithm>
 #include <exception>
-#include <random>
+#include <span>
 #include <thread>
 #include <vector>
 
 #include <CLI/CLI.hpp>
 #include <fmt/format.h>
 #include <fmt/ostream.h>
-#include <gsl/span>
 #include <range/v3/view/chunk.hpp>
 #include <range/v3/view/enumerate.hpp>
 #include <range/v3/view/iota.hpp>
@@ -16,11 +14,7 @@
 #include <tbb/global_control.h>
 
 #include "app.hpp"
-#include "binary_collection.hpp"
-#include "io.hpp"
 #include "sharding.hpp"
-#include "util/util.hpp"
-#include "vec_map.hpp"
 
 using namespace pisa;
 using ranges::views::chunk;
@@ -56,7 +50,7 @@ int main(int argc, char** argv) {
             partition_fwd_index(input_basename, output_basename, mapping);
         } else if (*shard_files_option) {
             auto mapping = mapping_from_files(
-                fmt::format("{}.documents", input_basename), gsl::make_span(shard_files)
+                fmt::format("{}.documents", input_basename), std::span(shard_files)
             );
             partition_fwd_index(input_basename, output_basename, mapping);
         } else {

--- a/tools/shards.cpp
+++ b/tools/shards.cpp
@@ -2,7 +2,6 @@
 #include <vector>
 
 #include <CLI/CLI.hpp>
-#include <gsl/span>
 #include <spdlog/sinks/stdout_color_sinks.h>
 #include <spdlog/spdlog.h>
 #include <tbb/global_control.h>

--- a/tools/taily_stats.cpp
+++ b/tools/taily_stats.cpp
@@ -1,6 +1,3 @@
-#include <iostream>
-#include <optional>
-
 #include <CLI/CLI.hpp>
 #include <mio/mmap.hpp>
 #include <spdlog/sinks/stdout_color_sinks.h>
@@ -9,10 +6,6 @@
 
 #include "./taily_stats.hpp"
 #include "app.hpp"
-#include "binary_freq_collection.hpp"
-#include "memory_source.hpp"
-#include "scorer/scorer.hpp"
-#include "util/progress.hpp"
 #include "wand_data.hpp"
 #include "wand_data_compressed.hpp"
 #include "wand_data_raw.hpp"

--- a/tools/taily_stats.hpp
+++ b/tools/taily_stats.hpp
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <gsl/span>
-
 #include "app.hpp"
 #include "pisa/taily_stats.hpp"
 #include "pisa/wand_data.hpp"


### PR DESCRIPTION
We mostly used GSL for its `span` class. After moving to the C++20 standard, we now have `std::span` available to us. It is more explicit in how it works because it's driven by the standard, and it allows us not to rely on a third party library.

`std::span` does no bound checks, so indexed access had to be guarded with explicit checks when necessary. Some helper functions were introduced, including equality operator.

`Expect` macros were replaced with `if` statements that throw `std::invalid_argument` if the contract is not upheld.

Changelog-changed: GSL is removed as dependency
Changelog-changed: gsl::span is replaced with std::span