### PR TITLE
Fix quantizer math

### DIFF
--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -85,9 +85,9 @@ jobs:
           sudo pip install clang-format
 
     - name: Set up Python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v5
       with:
-        python-version: 3.7
+        python-version: 3.13
 
     - name: Run clang-format
       shell: bash

--- a/include/pisa/linear_quantizer.hpp
+++ b/include/pisa/linear_quantizer.hpp
@@ -19,7 +19,6 @@ struct LinearQuantizer {
   private:
     std::uint32_t m_range;
     float m_max;
-    float m_scale;
 };
 
 }  // namespace pisa

--- a/src/linear_quantizer.cpp
+++ b/src/linear_quantizer.cpp
@@ -1,3 +1,4 @@
+#include <cassert>
 #include <cmath>
 #include <stdexcept>
 
@@ -6,17 +7,22 @@
 
 namespace pisa {
 
-LinearQuantizer::LinearQuantizer(float max, std::uint8_t bits)
-    : m_range((1U << bits) - 1U), m_max(max), m_scale(static_cast<float>(m_range - 1) / max) {
-    if (max <= 0.0) {
-        throw std::runtime_error(
-            fmt::format("Max score for linear quantizer must be positive but {} passed", max)
-        );
-    }
+[[nodiscard]] auto all_ones(std::uint32_t bits) -> std::uint32_t {
     if (bits > 32 or bits < 2) {
         throw std::runtime_error(fmt::format(
             "Linear quantizer must take a number of bits between 2 and 32 but {} passed", bits
         ));
+    }
+    auto half = std::uint32_t(1) << (bits - 1);
+    return half - 1 + half;
+}
+
+LinearQuantizer::LinearQuantizer(float max, std::uint8_t bits)
+    : m_range(all_ones(bits)), m_max(max) {
+    if (max <= 0.0) {
+        throw std::runtime_error(
+            fmt::format("Max score for linear quantizer must be positive but {} passed", max)
+        );
     }
 }
 
@@ -26,7 +32,8 @@ auto LinearQuantizer::operator()(float value) const -> std::uint32_t {
             fmt::format("quantized value must be between 0 and {} but {} given", m_max, value)
         );
     }
-    return std::round(value * m_scale) + 1;
+    auto normalized_value = static_cast<double>(value / m_max);
+    return static_cast<std::uint32_t>(normalized_value * (m_range - 1)) + 1;
 }
 
 auto LinearQuantizer::range() const noexcept -> std::uint32_t {

--- a/test/test_linear_quantizer.cpp
+++ b/test/test_linear_quantizer.cpp
@@ -26,6 +26,6 @@ TEST_CASE("LinearQuantizer", "[scoring][unit]") {
         CAPTURE(max);
         pisa::LinearQuantizer quantizer(max, bits);
         REQUIRE(quantizer(0) == 1);
-        REQUIRE(quantizer(max) == (1 << bits) - 1);
+        REQUIRE(quantizer(max) == static_cast<std::uint32_t>((std::uint64_t(1) << bits) - 1));
     }
 }


### PR DESCRIPTION
This fixes two issues. One was with precision, the other with overflow when 32 bits were used.

Fixes: https://github.com/pisa-engine/pisa/issues/597