### PR TITLE
Scorer option for `compute_intersection`

### DIFF
--- a/include/pisa/intersection.hpp
+++ b/include/pisa/intersection.hpp
@@ -51,22 +51,26 @@ struct Intersection {
     /// Maximum partial score in the intersection.
     float max_score;
 
-    template <typename Index, typename Wand>
+    template <typename Index, typename Wand, typename Scorer>
     inline static auto compute(
         Index const& index,
         Wand const& wand,
+        Scorer const& scorer,
         Query const& query,
         std::optional<intersection::Mask> term_mask = std::nullopt
     ) -> Intersection;
 };
 
-template <typename Index, typename Wand>
+template <typename Index, typename Wand, typename Scorer>
 inline auto Intersection::compute(
-    Index const& index, Wand const& wand, Query const& query, std::optional<intersection::Mask> term_mask
+    Index const& index,
+    Wand const& wand,
+    Scorer const& scorer,
+    Query const& query,
+    std::optional<intersection::Mask> term_mask
 ) -> Intersection {
     auto filtered_query = term_mask ? intersection::filter(query, *term_mask) : query;
     scored_and_query retrieve{};
-    auto scorer = scorer::from_params(ScorerParams("bm25"), wand);
     auto results = retrieve(make_scored_cursors(index, *scorer, filtered_query), index.num_docs());
     auto max_element = [&](auto const& vec) -> float {
         auto order = [](auto const& lhs, auto const& rhs) { return lhs.second < rhs.second; };

--- a/test/test_intersection.cpp
+++ b/test/test_intersection.cpp
@@ -115,6 +115,7 @@ TEST_CASE("compute intersection", "[intersection][unit]") {
             10
         };
         InMemoryWand wand{{0.0, 1.0, 0.0, 0.0, 0.0, 5.0, 6.0}, 10};
+        auto scorer = scorer::from_params(ScorerParams("bm25"), wand);
 
         Query query{
             "Q1",  // query ID
@@ -133,7 +134,7 @@ TEST_CASE("compute intersection", "[intersection][unit]") {
             })
         );
         WHEN("Computed intersection with mask " << mask) {
-            auto intersection = Intersection::compute(index, wand, query, mask);
+            auto intersection = Intersection::compute(index, wand, scorer, query, mask);
             CHECK(intersection.length == len);
             CHECK(intersection.max_score == Approx(max));
         }

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -35,3 +35,7 @@ add_tool(extract-maxscores extract_maxscores.cpp)
 add_tool(lookup-table lookup_table.cpp)
 
 configure_file(../script/ir-datasets.py ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ir-datasets COPYONLY)
+
+if (PISA_ENABLE_TESTING AND BUILD_TESTING)
+    add_subdirectory(tests)
+endif()

--- a/tools/compute_intersection.cpp
+++ b/tools/compute_intersection.cpp
@@ -104,7 +104,7 @@ int main(int argc, const char** argv) {
     auto queries = app.queries();
     auto filtered_queries = ranges::views::filter(queries, [&](auto&& query) {
         auto size = query.terms().size();
-        return size < min_query_len || size > max_query_len;
+        return min_query_len <= size && size <= max_query_len;
     });
 
     if (header) {

--- a/tools/tests/test_app.cpp
+++ b/tools/tests/test_app.cpp
@@ -20,8 +20,7 @@ struct Arguments {
     char** argv;
 
     explicit Arguments(std::vector<std::string> const& args)
-        : argc(args.size() + 1), argv(new char*[argc])
-    {
+        : argc(args.size() + 1), argv(new char*[argc]) {
         std::string name = "<executable>";
         argv[0] = new char[name.size() + 1];
         std::strcpy(argv[0], name.c_str());
@@ -34,8 +33,7 @@ struct Arguments {
     Arguments& operator=(Arguments const&) = delete;
     Arguments(Arguments&&) = default;
     Arguments& operator=(Arguments&&) = default;
-    ~Arguments()
-    {
+    ~Arguments() {
         if (argv != nullptr) {
             while (argc-- > 0) {
                 delete[] argv[argc];
@@ -52,79 +50,69 @@ struct Arguments {
  * when parsing fails, but here we need more control to catch potential errors,
  * so we call `CLI::App::parse` method directly.
  */
-void parse(CLI::App& app, std::vector<std::string> const& args)
-{
+void parse(CLI::App& app, std::vector<std::string> const& args) {
     ::Arguments input(args);
     app.parse(input.argc, input.argv);
 }
 
-TEST_CASE("Encoding", "[cli]")
-{
+TEST_CASE("Encoding", "[cli]") {
     CLI::App app("Encoding test");
     pisa::Args<pisa::arg::Encoding> args(&app);
-    SECTION("No arguments throws") { REQUIRE_THROWS(parse(app, {})); }
-    SECTION("Check encoding long option")
-    {
+    SECTION("No arguments throws") {
+        REQUIRE_THROWS(parse(app, {}));
+    }
+    SECTION("Check encoding long option") {
         // Note that we currently don't validate passed encoding until we use it,
         // so any string is valid at this point.
         REQUIRE_NOTHROW(parse(app, {"--encoding", "ENCODING"}));
         REQUIRE(args.index_encoding() == "ENCODING");
     }
-    SECTION("Check encoding short option")
-    {
+    SECTION("Check encoding short option") {
         REQUIRE_NOTHROW(parse(app, {"-e", "ENCODING"}));
         REQUIRE(args.index_encoding() == "ENCODING");
     }
 }
 
-TEST_CASE("WandData", "[cli]")
-{
+TEST_CASE("WandData", "[cli]") {
     CLI::App app("WandData test");
-    WHEN("WAND data is optional")
-    {
+    WHEN("WAND data is optional") {
         pisa::Args<pisa::arg::WandData<pisa::arg::WandMode::Optional>> args(&app);
-        SECTION("No arguments is OK")
-        {
+        SECTION("No arguments is OK") {
             REQUIRE_NOTHROW(parse(app, {}));
             REQUIRE_FALSE(args.wand_data_path().has_value());
         }
-        SECTION("Defined with long option")
-        {
+        SECTION("Defined with long option") {
             REQUIRE_NOTHROW(parse(app, {"--wand", "WDATA"}));
             REQUIRE(args.wand_data_path() == "WDATA");
             REQUIRE_FALSE(args.is_wand_compressed());
         }
-        SECTION("Defined with short option")
-        {
+        SECTION("Defined with short option") {
             REQUIRE_NOTHROW(parse(app, {"-w", "WDATA"}));
             REQUIRE(args.wand_data_path() == "WDATA");
             REQUIRE_FALSE(args.is_wand_compressed());
         }
-        SECTION("Compressed")
-        {
+        SECTION("Compressed") {
             REQUIRE_NOTHROW(parse(app, {"-w", "WDATA", "--compressed-wand"}));
             REQUIRE(args.wand_data_path() == "WDATA");
             REQUIRE(args.is_wand_compressed());
         }
     }
-    WHEN("WAND data is required")
-    {
+    WHEN("WAND data is required") {
         pisa::Args<pisa::arg::WandData<pisa::arg::WandMode::Required>> args(&app);
-        SECTION("No arguments throws") { REQUIRE_THROWS(parse(app, {})); }
-        SECTION("Defined with long option")
-        {
+        SECTION("No arguments throws") {
+            REQUIRE_THROWS(parse(app, {}));
+        }
+        SECTION("Defined with long option") {
             REQUIRE_NOTHROW(parse(app, {"--wand", "WDATA"}));
             REQUIRE(args.wand_data_path() == "WDATA");
             REQUIRE_FALSE(args.is_wand_compressed());
         }
-        SECTION("Defined with short option")
-        {
+        SECTION("Defined with short option") {
             REQUIRE_NOTHROW(parse(app, {"-w", "WDATA"}));
             REQUIRE(args.wand_data_path() == "WDATA");
             REQUIRE_FALSE(args.is_wand_compressed());
         }
-        SECTION("Compressed")
-        {
+        SECTION("Compressed") {
             REQUIRE_NOTHROW(parse(app, {"-w", "WDATA", "--compressed-wand"}));
             REQUIRE(args.wand_data_path() == "WDATA");
             REQUIRE(args.is_wand_compressed());
@@ -132,21 +120,24 @@ TEST_CASE("WandData", "[cli]")
     }
 }
 
-TEST_CASE("Index", "[cli]")
-{
+TEST_CASE("Index", "[cli]") {
     CLI::App app("Index test");
     pisa::Args<pisa::arg::Index> args(&app);
-    SECTION("No arguments throws") { REQUIRE_THROWS(parse(app, {})); }
-    SECTION("Only encoding throws") { REQUIRE_THROWS(parse(app, {"--encoding", "ENCODING"})); }
-    SECTION("Only index throws") { REQUIRE_THROWS(parse(app, {"--index", "INDEX"})); }
-    SECTION("Check long options")
-    {
+    SECTION("No arguments throws") {
+        REQUIRE_THROWS(parse(app, {}));
+    }
+    SECTION("Only encoding throws") {
+        REQUIRE_THROWS(parse(app, {"--encoding", "ENCODING"}));
+    }
+    SECTION("Only index throws") {
+        REQUIRE_THROWS(parse(app, {"--index", "INDEX"}));
+    }
+    SECTION("Check long options") {
         REQUIRE_NOTHROW(parse(app, {"--encoding", "ENCODING", "--index", "INDEX"}));
         REQUIRE(args.index_encoding() == "ENCODING");
         REQUIRE(args.index_filename() == "INDEX");
     }
-    SECTION("Check short options")
-    {
+    SECTION("Check short options") {
         REQUIRE_NOTHROW(parse(app, {"-e", "ENCODING", "-i", "INDEX"}));
         REQUIRE(args.index_encoding() == "ENCODING");
         REQUIRE(args.index_filename() == "INDEX");
@@ -159,8 +150,8 @@ TEST_CASE("Index", "[cli]")
 void test_tokenizer(
     std::unique_ptr<pisa::Tokenizer> const& tokenizer,
     std::string_view input,
-    std::vector<std::string> const& expected)
-{
+    std::vector<std::string> const& expected
+) {
     auto stream = tokenizer->tokenize(input);
     std::vector<std::string> actual(stream->begin(), stream->end());
     REQUIRE(actual == expected);
@@ -170,101 +161,91 @@ void test_tokenizer(
  * Verifies that the given analyzer produces the expected stream of tokens on the given input.
  */
 void test_analyzer(
-    pisa::TextAnalyzer const& tokenizer,
-    std::string_view input,
-    std::vector<std::string> const& expected)
-{
+    pisa::TextAnalyzer const& tokenizer, std::string_view input, std::vector<std::string> const& expected
+) {
     auto stream = tokenizer.analyze(input);
     std::vector<std::string> actual(stream->begin(), stream->end());
     REQUIRE(actual == expected);
 }
 
-void write_lines(std::filesystem::path const& path, std::vector<std::string> const& lines)
-{
+void write_lines(std::filesystem::path const& path, std::vector<std::string> const& lines) {
     std::ofstream out(path.c_str());
     for (auto const& line: lines) {
         out << line << '\n';
     }
 }
 
-TEST_CASE("Analyzer", "[cli]")
-{
+TEST_CASE("Analyzer", "[cli]") {
     CLI::App app("Analyzer test");
     pisa::Args<pisa::arg::Analyzer> args(&app);
-    SECTION("Defaults")
-    {
+    SECTION("Defaults") {
         parse(app, {});
         test_tokenizer(args.tokenizer(), "A's b c's", {"A", "b", "c"});
         test_analyzer(args.text_analyzer(), "A's b c's", {"A", "b", "c"});
     }
-    SECTION("English tokenizer")
-    {
+    SECTION("English tokenizer") {
         parse(app, {});
         test_tokenizer(args.tokenizer(), "A's b c's", {"A", "b", "c"});
         test_analyzer(args.text_analyzer(), "A's b c's", {"A", "b", "c"});
     }
-    SECTION("Whitespace tokenizer")
-    {
+    SECTION("Whitespace tokenizer") {
         parse(app, {"--tokenizer", "whitespace"});
         test_tokenizer(args.tokenizer(), "A's b c's", {"A's", "b", "c's"});
         test_analyzer(args.text_analyzer(), "A's b c's", {"A's", "b", "c's"});
     }
-    SECTION("Lowercase")
-    {
+    SECTION("Lowercase") {
         parse(app, {"--token-filters", "lowercase"});
         test_tokenizer(args.tokenizer(), "A's b c's", {"A", "b", "c"});
         test_analyzer(args.text_analyzer(), "A's b c's", {"a", "b", "c"});
     }
-    SECTION("Lowercase & Porter2")
-    {
+    SECTION("Lowercase & Porter2") {
         parse(app, {"--token-filters", "lowercase", "porter2"});
         test_tokenizer(args.tokenizer(), "A's b c's flying", {"A", "b", "c", "flying"});
         test_analyzer(args.text_analyzer(), "A's b c's flying", {"a", "b", "c", "fli"});
     }
-    SECTION("Krovetz")
-    {
+    SECTION("Krovetz") {
         parse(app, {"--token-filters", "krovetz"});
         test_tokenizer(
-            args.tokenizer(), "A's b c's flying playing", {"A", "b", "c", "flying", "playing"});
+            args.tokenizer(), "A's b c's flying playing", {"A", "b", "c", "flying", "playing"}
+        );
         // Note: Krovetz seems to: (a) lowercase, and (b) not stem words like "flying"
         test_analyzer(
-            args.text_analyzer(), "A's b c's flying playing", {"a", "b", "c", "flying", "play"});
+            args.text_analyzer(), "A's b c's flying playing", {"a", "b", "c", "flying", "play"}
+        );
     }
-    SECTION("Stopwords")
-    {
+    SECTION("Stopwords") {
         pisa::TemporaryDirectory dir;
         auto stopwords_path = dir.path() / "stopwords.txt";
         write_lines(
             stopwords_path,
             {"fli",  // Adding stemmed to make sure stopwords are removed at the end
-             "b"});
+             "b"}
+        );
 
         parse(
-            app,
-            {"--stopwords", stopwords_path.string(), "--token-filters", "lowercase", "porter2"});
+            app, {"--stopwords", stopwords_path.string(), "--token-filters", "lowercase", "porter2"}
+        );
         test_tokenizer(args.tokenizer(), "A's b c's flying", {"A", "b", "c", "flying"});
         test_analyzer(args.text_analyzer(), "A's b c's flying", {"a", "c"});
     }
 }
 
-TEST_CASE("Ranked Query", "[cli]")
-{
+TEST_CASE("Ranked Query", "[cli]") {
     CLI::App app("Analyzer test");
     pisa::Args<pisa::arg::Query<>> args(&app);
 
-    SECTION("Throws without arguments -- queries are required") { REQUIRE_THROWS(parse(app, {})); }
+    SECTION("Throws without arguments -- queries are required") {
+        REQUIRE_THROWS(parse(app, {}));
+    }
 
-    GIVEN("Non-existend input file path")
-    {
+    GIVEN("Non-existent input file path") {
         auto queries = std::filesystem::path("queries.txt");
-        THEN("File cannot be read and it throws")
-        {
+        THEN("File cannot be read and it throws") {
             REQUIRE_THROWS(parse(app, {"--queries", queries.string()}));
         }
     }
 
-    GIVEN("Input file with term IDs and query IDs")
-    {
+    GIVEN("Input file with term IDs and query IDs") {
         pisa::TemporaryDirectory dir;
 
         auto queries = dir.path() / "queries.txt";
@@ -279,67 +260,67 @@ TEST_CASE("Ranked Query", "[cli]")
         auto termlex = pisa::encode_payload_vector(term_vector.begin(), term_vector.end());
         termlex.to_file(terms.string());
 
-        WHEN("Only query file is provided")
-        {
+        WHEN("Only query file is provided") {
             std::vector<std::string> input{"--queries", queries.string()};
-            THEN("Fails due to missing k") { REQUIRE_THROWS(parse(app, input)); }
-        }
-
-        WHEN("Query file and k are provided")
-        {
-            std::vector<std::string> input{"--queries", queries.string(), "-k", "100"};
-            THEN("Parses queries using term IDs")
-            {
-                parse(app, input);
-                auto qs = args.queries();
-                REQUIRE(qs.size() == 3);
-
-                REQUIRE(qs[0].id == "1");
-                REQUIRE(qs[0].terms == std::vector<std::uint32_t>{0, 1, 2});
-                REQUIRE(qs[0].term_weights.empty());
-
-                REQUIRE(qs[1].id == std::nullopt);
-                REQUIRE(qs[1].terms == std::vector<std::uint32_t>{3, 4, 5});
-                REQUIRE(qs[1].term_weights.empty());
-
-                REQUIRE(qs[2].id == "3");
-                REQUIRE(qs[2].terms == std::vector<std::uint32_t>{6, 7, 8});
-                REQUIRE(qs[2].term_weights.empty());
+            THEN("Fails due to missing k") {
+                REQUIRE_THROWS(parse(app, input));
             }
         }
 
-        WHEN("Query file, k, and terms are provided")
-        {
-            std::vector<std::string> input{
-                "--queries", queries.string(), "-k", "100", "--terms", terms.string()};
-            THEN("Considers numbers from input as strings")
-            {
+        WHEN("Query file and k are provided") {
+            std::vector<std::string> input{"--queries", queries.string(), "-k", "100"};
+            THEN("Parses queries using term IDs") {
                 parse(app, input);
                 auto qs = args.queries();
                 REQUIRE(qs.size() == 3);
 
-                REQUIRE(qs[0].id == "1");
-                REQUIRE(qs[0].terms == std::vector<std::uint32_t>{0, 2, 4});
-                REQUIRE(qs[0].term_weights.empty());
+                REQUIRE(qs[0].id() == "1");
+                REQUIRE(
+                    qs[0].terms() == std::vector<pisa::WeightedTerm>{{0, 1.0F}, {1, 1.0F}, {2, 1.0F}}
+                );
 
-                REQUIRE(qs[1].id == std::nullopt);
-                REQUIRE(qs[1].terms == std::vector<std::uint32_t>{6, 8, 10});
-                REQUIRE(qs[1].term_weights.empty());
+                REQUIRE(qs[1].id() == std::nullopt);
+                REQUIRE(
+                    qs[1].terms() == std::vector<pisa::WeightedTerm>{{3, 1.0F}, {4, 1.0F}, {5, 1.0F}}
+                );
 
-                REQUIRE(qs[2].id == "3");
-                REQUIRE(qs[2].terms == std::vector<std::uint32_t>{12, 14});
-                REQUIRE(qs[2].term_weights.empty());
+                REQUIRE(qs[2].id() == "3");
+                REQUIRE(
+                    qs[2].terms() == std::vector<pisa::WeightedTerm>{{6, 1.0F}, {7, 1.0F}, {8, 1.0F}}
+                );
+            }
+        }
+
+        WHEN("Query file, k, and terms are provided") {
+            std::vector<std::string> input{
+                "--queries", queries.string(), "-k", "100", "--terms", terms.string()
+            };
+            THEN("Considers numbers from input as strings") {
+                parse(app, input);
+                auto qs = args.queries();
+                REQUIRE(qs.size() == 3);
+
+                REQUIRE(qs[0].id() == "1");
+                REQUIRE(
+                    qs[0].terms() == std::vector<pisa::WeightedTerm>{{0, 1.0F}, {2, 1.0F}, {4, 1.0F}}
+                );
+
+                REQUIRE(qs[1].id() == std::nullopt);
+                REQUIRE(
+                    qs[1].terms() == std::vector<pisa::WeightedTerm>{{6, 1.0F}, {8, 1.0F}, {10, 1.0F}}
+                );
+
+                REQUIRE(qs[2].id() == "3");
+                REQUIRE(qs[2].terms() == std::vector<pisa::WeightedTerm>{{12, 1.0F}, {14, 1.0F}});
             }
         }
     }
 
-    GIVEN("Input file with terms and query IDs")
-    {
+    GIVEN("Input file with terms and query IDs") {
         pisa::TemporaryDirectory dir;
 
         auto queries = dir.path() / "queries.txt";
-        write_lines(
-            queries, {"1:dog dog dog", "dog cat mouse" /* missing qid */, "3:pelican moose"});
+        write_lines(queries, {"1:dog dog dog", "dog cat mouse" /* missing qid */, "3:pelican moose"});
 
         auto terms = dir.path() / "terms.txt";
         std::vector<std::string> term_vector = {
@@ -352,62 +333,56 @@ TEST_CASE("Ranked Query", "[cli]")
         auto termlex = pisa::encode_payload_vector(term_vector.begin(), term_vector.end());
         termlex.to_file(terms.string());
 
-        WHEN("Query file and k are provided")
-        {
+        WHEN("Query file and k are provided") {
             std::vector<std::string> input{"--queries", queries.string(), "-k", "100"};
-            THEN("Fails to parse term IDs in the file")
-            {
+            THEN("Fails to parse term IDs in the file") {
                 parse(app, input);
                 REQUIRE_THROWS(args.queries());
             }
         }
 
-        WHEN("Query file, k, and terms are provided")
-        {
+        WHEN("Query file, k, and terms are provided") {
             std::vector<std::string> input{
-                "--queries", queries.string(), "-k", "100", "--terms", terms.string()};
-            THEN("Translates the terms into IDs")
-            {
+                "--queries", queries.string(), "-k", "100", "--terms", terms.string()
+            };
+            THEN("Translates the terms into IDs") {
                 parse(app, input);
                 auto qs = args.queries();
                 REQUIRE(qs.size() == 3);
 
-                REQUIRE(qs[0].id == "1");
-                REQUIRE(qs[0].terms == std::vector<std::uint32_t>{1, 1, 1});
-                REQUIRE(qs[0].term_weights.empty());
+                REQUIRE(qs[0].id() == "1");
+                REQUIRE(qs[0].terms() == std::vector<pisa::WeightedTerm>{{1, 3.0F}});
 
-                REQUIRE(qs[1].id == std::nullopt);
-                REQUIRE(qs[1].terms == std::vector<std::uint32_t>{1, 0, 2});
-                REQUIRE(qs[1].term_weights.empty());
+                REQUIRE(qs[1].id() == std::nullopt);
+                REQUIRE(
+                    qs[1].terms() == std::vector<pisa::WeightedTerm>{{1, 1.0F}, {0, 1.0F}, {2, 1.0F}}
+                );
 
-                REQUIRE(qs[2].id == "3");
-                REQUIRE(qs[2].terms == std::vector<std::uint32_t>{3});
-                REQUIRE(qs[2].term_weights.empty());
+                REQUIRE(qs[2].id() == "3");
+                REQUIRE(qs[2].terms() == std::vector<pisa::WeightedTerm>{{3, 1.0F}});
             }
         }
 
         // If this behavior surprises you, see https://github.com/pisa-engine/pisa/issues/501
-        WHEN("Query file, k, and terms are provided, and --weighted is passed")
-        {
+        WHEN("Query file, k, and terms are provided, and --weighted is passed") {
             std::vector<std::string> input{
-                "--queries", queries.string(), "-k", "100", "--terms", terms.string(), "--weighted"};
-            THEN("Translates the terms into IDs")
-            {
+                "--queries", queries.string(), "-k", "100", "--terms", terms.string(), "--weighted"
+            };
+            THEN("Translates the terms into IDs") {
                 parse(app, input);
                 auto qs = args.queries();
                 REQUIRE(qs.size() == 3);
 
-                REQUIRE(qs[0].id == "1");
-                REQUIRE(qs[0].terms == std::vector<std::uint32_t>{1, 1, 1});
-                REQUIRE(qs[0].term_weights.empty());
+                REQUIRE(qs[0].id() == "1");
+                REQUIRE(qs[0].terms() == std::vector<pisa::WeightedTerm>{{1, 3.0F}});
 
-                REQUIRE(qs[1].id == std::nullopt);
-                REQUIRE(qs[1].terms == std::vector<std::uint32_t>{1, 0, 2});
-                REQUIRE(qs[1].term_weights.empty());
+                REQUIRE(qs[1].id() == std::nullopt);
+                REQUIRE(
+                    qs[1].terms() == std::vector<pisa::WeightedTerm>{{1, 1.0F}, {0, 1.0F}, {2, 1.0F}}
+                );
 
-                REQUIRE(qs[2].id == "3");
-                REQUIRE(qs[2].terms == std::vector<std::uint32_t>{3});
-                REQUIRE(qs[2].term_weights.empty());
+                REQUIRE(qs[2].id() == "3");
+                REQUIRE(qs[2].terms() == std::vector<pisa::WeightedTerm>{{3, 1.0F}});
 
                 REQUIRE(args.weighted());
             }
@@ -415,32 +390,31 @@ TEST_CASE("Ranked Query", "[cli]")
     }
 }
 
-TEST_CASE("Algorithm", "[cli]")
-{
+TEST_CASE("Algorithm", "[cli]") {
     CLI::App app("Algorithm test");
     pisa::Args<pisa::arg::Algorithm> args(&app);
-    SECTION("No arguments throws") { REQUIRE_THROWS(parse(app, {})); }
-    SECTION("Long option")
-    {
+    SECTION("No arguments throws") {
+        REQUIRE_THROWS(parse(app, {}));
+    }
+    SECTION("Long option") {
         // Note: algorithm names are not validated until later.
         parse(app, {"--algorithm", "ALG"});
         REQUIRE(args.algorithm() == "ALG");
     }
-    SECTION("Short option")
-    {
+    SECTION("Short option") {
         // Note: algorithm names are not validated until later.
         parse(app, {"-a", "ALG"});
         REQUIRE(args.algorithm() == "ALG");
     }
 }
 
-TEST_CASE("Scorer", "[cli]")
-{
+TEST_CASE("Scorer", "[cli]") {
     CLI::App app("Scorer test");
     pisa::Args<pisa::arg::Scorer> args(&app);
-    SECTION("No arguments throws") { REQUIRE_THROWS(parse(app, {})); }
-    SECTION("Long option with defaults")
-    {
+    SECTION("No arguments throws") {
+        REQUIRE_THROWS(parse(app, {}));
+    }
+    SECTION("Long option with defaults") {
         parse(app, {"--scorer", "scorer"});
         auto params = args.scorer_params();
         REQUIRE(params.name == "scorer");
@@ -449,8 +423,7 @@ TEST_CASE("Scorer", "[cli]")
         REQUIRE(params.pl2_c == 1.0F);
         REQUIRE(params.qld_mu == 1000.0F);
     }
-    SECTION("Short option")
-    {
+    SECTION("Short option") {
         parse(
             app,
             {"-s",
@@ -462,7 +435,8 @@ TEST_CASE("Scorer", "[cli]")
              "--pl2-c",
              "1.1",
              "--qld-mu",
-             "1001"});
+             "1001"}
+        );
         auto params = args.scorer_params();
         REQUIRE(params.name == "scorer");
         REQUIRE(params.bm25_b == 0.5F);
@@ -472,18 +446,17 @@ TEST_CASE("Scorer", "[cli]")
     }
 }
 
-TEST_CASE("Quantize", "[cli]")
-{
+TEST_CASE("Quantize", "[cli]") {
     CLI::App app("Scorer test");
     pisa::Args<pisa::arg::Quantize> args(&app);
-    SECTION("Scorer without --quantize throws")
-    {
+    SECTION("Scorer without --quantize throws") {
         REQUIRE_THROWS(parse(app, {"--scorer", "scorer"}));
     }
-    SECTION("Wand without --quantize throws") { REQUIRE_THROWS(parse(app, {"--wand", "WAND"})); }
-    SECTION("Long scorer & wand options with defaults")
-    {
-        parse(app, {"--quantize", "--scorer", "scorer", "--wand", "WAND"});
+    SECTION("Wand without --quantize throws") {
+        REQUIRE_THROWS(parse(app, {"--wand", "WAND"}));
+    }
+    SECTION("Long scorer & wand options with defaults") {
+        parse(app, {"--quantize", "8", "--scorer", "scorer", "--wand", "WAND"});
         auto params = args.scorer_params();
         REQUIRE(params.name == "scorer");
         REQUIRE(params.bm25_b == 0.4F);
@@ -491,11 +464,11 @@ TEST_CASE("Quantize", "[cli]")
         REQUIRE(params.pl2_c == 1.0F);
         REQUIRE(params.qld_mu == 1000.0F);
     }
-    SECTION("Short scorer & wand options")
-    {
+    SECTION("Short scorer & wand options") {
         parse(
             app,
             {"--quantize",
+             "8",
              "-s",
              "scorer",
              "--bm25-b",
@@ -507,7 +480,8 @@ TEST_CASE("Quantize", "[cli]")
              "--qld-mu",
              "1001",
              "--wand",
-             "WAND"});
+             "WAND"}
+        );
         auto params = args.scorer_params();
         REQUIRE(params.name == "scorer");
         REQUIRE(params.bm25_b == 0.5F);
@@ -517,96 +491,85 @@ TEST_CASE("Quantize", "[cli]")
     }
 }
 
-TEST_CASE("Thresholds", "[cli]")
-{
+TEST_CASE("Thresholds", "[cli]") {
     CLI::App app("Thresholds test");
     pisa::Args<pisa::arg::Thresholds> args(&app);
-    SECTION("Long option")
-    {
+    SECTION("Long option") {
         parse(app, {"--thresholds", "THRESHOLDS"});
         REQUIRE(args.thresholds_file() == "THRESHOLDS");
     }
-    SECTION("Short option")
-    {
+    SECTION("Short option") {
         parse(app, {"-T", "THRESHOLDS"});
         REQUIRE(args.thresholds_file() == "THRESHOLDS");
     }
 }
 
-TEST_CASE("Verbose", "[cli]")
-{
+TEST_CASE("Verbose", "[cli]") {
     CLI::App app("Verbose test");
     pisa::Args<pisa::arg::Verbose> args(&app);
-    SECTION("By default not verbose")
-    {
+    SECTION("By default not verbose") {
         parse(app, {});
         REQUIRE_FALSE(args.verbose());
     }
-    SECTION("Long option")
-    {
+    SECTION("Long option") {
         parse(app, {"--verbose"});
         REQUIRE(args.verbose());
     }
-    SECTION("Short option")
-    {
+    SECTION("Short option") {
         parse(app, {"-v"});
         REQUIRE(args.verbose());
     }
 }
 
-TEST_CASE("Threads", "[cli]")
-{
+TEST_CASE("Threads", "[cli]") {
     CLI::App app("Threads test");
     pisa::Args<pisa::arg::Threads> args(&app);
-    SECTION("By default equal to hardware concurrency")
-    {
+    SECTION("By default equal to hardware concurrency") {
         parse(app, {});
         REQUIRE(args.threads() == std::thread::hardware_concurrency());
     }
-    SECTION("Long option")
-    {
+    SECTION("Long option") {
         parse(app, {"--threads", "10"});
         REQUIRE(args.threads() == 10);
     }
-    SECTION("Short option")
-    {
+    SECTION("Short option") {
         parse(app, {"-j", "10"});
         REQUIRE(args.threads() == 10);
     }
 }
 
-TEST_CASE("Batch size", "[cli]")
-{
+TEST_CASE("Batch size", "[cli]") {
     CLI::App app("Batch size test");
     pisa::Args<pisa::arg::BatchSize<100>> args(&app);
-    SECTION("Default")
-    {
+    SECTION("Default") {
         parse(app, {});
         REQUIRE(args.batch_size() == 100);
     }
-    SECTION("Long option")
-    {
+    SECTION("Long option") {
         parse(app, {"--batch-size", "200"});
         REQUIRE(args.batch_size() == 200);
     }
 }
 
-TEST_CASE("Invert", "[cli]")
-{
+TEST_CASE("Invert", "[cli]") {
     CLI::App app("Invert test");
     pisa::Args<pisa::arg::Invert> args(&app);
-    SECTION("Throws without arguments") { REQUIRE_THROWS(parse(app, {})); }
-    SECTION("Throws with input only") { REQUIRE_THROWS(parse(app, {"--input", "INPUT"})); }
-    SECTION("Throws with output only") { REQUIRE_THROWS(parse(app, {"--output", "OUTPUT"})); }
-    SECTION("Short options")
-    {
+    SECTION("Throws without arguments") {
+        REQUIRE_THROWS(parse(app, {}));
+    }
+    SECTION("Throws with input only") {
+        REQUIRE_THROWS(parse(app, {"--input", "INPUT"}));
+    }
+    SECTION("Throws with output only") {
+        REQUIRE_THROWS(parse(app, {"--output", "OUTPUT"}));
+    }
+    SECTION("Short options") {
         parse(app, {"-i", "INPUT", "-o", "OUTPUT"});
         REQUIRE(args.input_basename() == "INPUT");
         REQUIRE(args.output_basename() == "OUTPUT");
         REQUIRE(args.term_count() == std::nullopt);
     }
-    SECTION("With term count")
-    {
+    SECTION("With term count") {
         parse(app, {"--input", "INPUT", "--output", "OUTPUT", "--term-count", "123"});
         REQUIRE(args.input_basename() == "INPUT");
         REQUIRE(args.output_basename() == "OUTPUT");
@@ -614,25 +577,25 @@ TEST_CASE("Invert", "[cli]")
     }
 }
 
-TEST_CASE("Compress", "[cli]")
-{
+TEST_CASE("Compress", "[cli]") {
     CLI::App app("Compress test");
     pisa::Args<pisa::arg::Compress> args(&app);
-    SECTION("Throws without arguments") { REQUIRE_THROWS(parse(app, {})); }
-    SECTION("Throws with collection only")
-    {
+    SECTION("Throws without arguments") {
+        REQUIRE_THROWS(parse(app, {}));
+    }
+    SECTION("Throws with collection only") {
         REQUIRE_THROWS(parse(app, {"--collection", "COLLECTION"}));
     }
-    SECTION("Throws with output only") { REQUIRE_THROWS(parse(app, {"--output", "OUTPUT"})); }
-    SECTION("Short options")
-    {
+    SECTION("Throws with output only") {
+        REQUIRE_THROWS(parse(app, {"--output", "OUTPUT"}));
+    }
+    SECTION("Short options") {
         parse(app, {"-c", "COLLECTION", "-o", "OUTPUT"});
         REQUIRE(args.input_basename() == "COLLECTION");
         REQUIRE(args.output() == "OUTPUT");
         REQUIRE_FALSE(args.check());
     }
-    SECTION("With check")
-    {
+    SECTION("With check") {
         parse(app, {"--collection", "COLLECTION", "--output", "OUTPUT", "--check"});
         REQUIRE(args.input_basename() == "COLLECTION");
         REQUIRE(args.output() == "OUTPUT");
@@ -640,33 +603,31 @@ TEST_CASE("Compress", "[cli]")
     }
 }
 
-TEST_CASE("CreateWandData", "[cli]")
-{
+TEST_CASE("CreateWandData", "[cli]") {
     CLI::App app("CreateWandData test");
     pisa::Args<pisa::arg::CreateWandData> args(&app);
-    SECTION("Throws without arguments") { REQUIRE_THROWS(parse(app, {})); }
-    SECTION("Throws without scorer")
-    {
-        REQUIRE_THROWS(
-            parse(app, {"--collection", "COLLECTION", "--output", "OUTPUT", "--block-size", "10"}));
+    SECTION("Throws without arguments") {
+        REQUIRE_THROWS(parse(app, {}));
     }
-    SECTION("Throws without collection")
-    {
+    SECTION("Throws without scorer") {
         REQUIRE_THROWS(
-            parse(app, {"--scorer", "SCORER", "--output", "OUTPUT", "--block-size", "10"}));
+            parse(app, {"--collection", "COLLECTION", "--output", "OUTPUT", "--block-size", "10"})
+        );
     }
-    SECTION("Throws without output")
-    {
+    SECTION("Throws without collection") {
+        REQUIRE_THROWS(parse(app, {"--scorer", "SCORER", "--output", "OUTPUT", "--block-size", "10"}));
+    }
+    SECTION("Throws without output") {
         REQUIRE_THROWS(
-            parse(app, {"--scorer", "SCORER", "--collection", "COLLECTION", "--block-size", "10"}));
+            parse(app, {"--scorer", "SCORER", "--collection", "COLLECTION", "--block-size", "10"})
+        );
     }
-    SECTION("Throws without block size or lambda")
-    {
+    SECTION("Throws without block size or lambda") {
         REQUIRE_THROWS(
-            parse(app, {"--collection", "COLLECTION", "--output", "OUTPUT", "--scorer", "SCORER"}));
+            parse(app, {"--collection", "COLLECTION", "--output", "OUTPUT", "--scorer", "SCORER"})
+        );
     }
-    SECTION("Defaults with block size")
-    {
+    SECTION("Defaults with block size") {
         parse(
             app,
             {"--collection",
@@ -676,18 +637,18 @@ TEST_CASE("CreateWandData", "[cli]")
              "--scorer",
              "SCORER",
              "--block-size",
-             "10"});
+             "10"}
+        );
         REQUIRE(args.input_basename() == "COLLECTION");
         REQUIRE(args.output() == "OUTPUT");
         REQUIRE(args.scorer_params().name == "SCORER");
         REQUIRE_FALSE(args.compress());
-        REQUIRE_FALSE(args.quantize());
+        REQUIRE_FALSE(args.quantization_bits());
         REQUIRE_FALSE(args.range());
         REQUIRE(args.dropped_term_ids().empty());
         REQUIRE(std::get<pisa::FixedBlock>(args.block_size()).size == 10);
     }
-    SECTION("With lambda and other options")
-    {
+    SECTION("With lambda and other options") {
         parse(
             app,
             {"--collection",
@@ -699,18 +660,19 @@ TEST_CASE("CreateWandData", "[cli]")
              "--lambda",
              "0.5",
              "--compress",
-             "--quantize"});
+             "--quantize",
+             "8"}
+        );
         REQUIRE(args.input_basename() == "COLLECTION");
         REQUIRE(args.output() == "OUTPUT");
         REQUIRE(args.scorer_params().name == "SCORER");
         REQUIRE(args.compress());
-        REQUIRE(args.quantize());
+        REQUIRE(args.quantization_bits() == std::optional<pisa::Size>(8));
         REQUIRE_FALSE(args.range());
         REQUIRE(args.dropped_term_ids().empty());
         REQUIRE(std::get<pisa::VariableBlock>(args.block_size()).lambda == 0.5);
     }
-    SECTION("With range")
-    {
+    SECTION("With range") {
         // TODO: This currently does not work!
         //       See https://github.com/pisa-engine/pisa/issues/502
         // parse(
@@ -721,12 +683,11 @@ TEST_CASE("CreateWandData", "[cli]")
         // REQUIRE(args.output() == "OUTPUT");
         // REQUIRE(args.scorer_params().name == "SCORER");
         // REQUIRE_FALSE(args.compress());
-        // REQUIRE_FALSE(args.quantize());
+        // REQUIRE_FALSE(args.quantization_bits());
         // REQUIRE(args.range());
         // REQUIRE(args.dropped_term_ids().empty());
     }
-    SECTION("Terms to drop")
-    {
+    SECTION("Terms to drop") {
         pisa::TemporaryDirectory dir;
         auto terms_to_drop_path = dir.path() / "terms_to_drop.txt";
         write_lines(terms_to_drop_path, {"1", "2", "3"});
@@ -741,31 +702,30 @@ TEST_CASE("CreateWandData", "[cli]")
              "--block-size",
              "10",
              "--terms-to-drop",
-             terms_to_drop_path.string()});
+             terms_to_drop_path.string()}
+        );
         REQUIRE(args.dropped_term_ids() == std::unordered_set<std::size_t>{1, 2, 3});
     }
 }
 
-TEST_CASE("ReorderDocuments", "[cli]")
-{
+TEST_CASE("ReorderDocuments", "[cli]") {
     CLI::App app("ReorderDocuments test");
     pisa::Args<pisa::arg::ReorderDocuments> args(&app);
-    SECTION("Throws without arguments") { REQUIRE_THROWS(parse(app, {})); }
-    SECTION("Random")
-    {
+    SECTION("Throws without arguments") {
+        REQUIRE_THROWS(parse(app, {}));
+    }
+    SECTION("Random") {
         parse(app, {"--collection", "INPUT", "--output", "OUTPUT", "--random"});
         REQUIRE(args.random());
         REQUIRE_FALSE(args.bp());
     }
-    SECTION("Random seed")
-    {
+    SECTION("Random seed") {
         parse(app, {"--collection", "INPUT", "--output", "OUTPUT", "--random", "--seed", "17"});
         REQUIRE(args.random());
         REQUIRE_FALSE(args.bp());
         REQUIRE(args.seed() == 17ULL);
     }
-    SECTION("Reordered documents cannot be written if not passed")
-    {
+    SECTION("Reordered documents cannot be written if not passed") {
         REQUIRE_THROWS(parse(
             app,
             {"--collection",
@@ -774,10 +734,10 @@ TEST_CASE("ReorderDocuments", "[cli]")
              "OUTPUT",
              "--random",
              "--reordered-documents",
-             "REORDERD"}));
+             "REORDERD"}
+        ));
     }
-    SECTION("Reordered documents")
-    {
+    SECTION("Reordered documents") {
         parse(
             app,
             {"--collection",
@@ -788,82 +748,141 @@ TEST_CASE("ReorderDocuments", "[cli]")
              "--documents",
              "DOCLEX",
              "--reordered-documents",
-             "REORDERED"});
+             "REORDERED"}
+        );
         REQUIRE(args.random());
         REQUIRE_FALSE(args.bp());
         REQUIRE(*args.reordered_document_lexicon() == "REORDERED");
     }
-    SECTION("From mapping")
-    {
+    SECTION("From mapping") {
         parse(app, {"--collection", "INPUT", "--output", "OUTPUT", "--from-mapping", "MAPPING"});
         REQUIRE_FALSE(args.random());
         REQUIRE_FALSE(args.bp());
         REQUIRE(*args.mapping_file() == "MAPPING");
     }
-    SECTION("By feature")
-    {
+    SECTION("By feature") {
         parse(app, {"--collection", "INPUT", "--output", "OUTPUT", "--by-feature", "FEATURE"});
         REQUIRE_FALSE(args.random());
         REQUIRE_FALSE(args.bp());
         REQUIRE(*args.feature_file() == "FEATURE");
     }
-    SECTION("BP")
-    {
+    SECTION("BP") {
         parse(app, {"--collection", "INPUT", "--output", "OUTPUT", "--bp"});
         REQUIRE_FALSE(args.random());
         REQUIRE(args.bp());
     }
 }
 
-TEST_CASE("Separator", "[cli]")
-{
+TEST_CASE("Separator", "[cli]") {
     CLI::App app("Separator test");
     pisa::Args<pisa::arg::Separator> args(&app);
-    SECTION("Default")
-    {
+    SECTION("Default") {
         parse(app, {});
         REQUIRE(args.separator() == "\t");
     }
-    SECTION("Defined")
-    {
+    SECTION("Defined") {
         parse(app, {"--sep", ","});
         REQUIRE(args.separator() == ",");
     }
 }
 
-TEST_CASE("PrintQueryId", "[cli]")
-{
+TEST_CASE("PrintQueryId", "[cli]") {
     CLI::App app("PrintQueryId test");
     pisa::Args<pisa::arg::PrintQueryId> args(&app);
-    SECTION("Default")
-    {
+    SECTION("Default") {
         parse(app, {});
         REQUIRE_FALSE(args.print_query_id());
     }
-    SECTION("Defined")
-    {
+    SECTION("Defined") {
         parse(app, {"--query-id"});
         REQUIRE(args.print_query_id());
     }
 }
 
-TEST_CASE("LogLevel", "[cli]")
-{
+TEST_CASE("LogLevel", "[cli]") {
     CLI::App app("LogLevel test");
     pisa::Args<pisa::arg::LogLevel> args(&app);
-    SECTION("Default is info")
-    {
+    SECTION("Default is info") {
         parse(app, {});
         REQUIRE(args.log_level() == spdlog::level::level_enum::info);
     }
-    SECTION("Error")
-    {
+    SECTION("Error") {
         parse(app, {"--log-level", "err"});
         REQUIRE(args.log_level() == spdlog::level::level_enum::err);
     }
-    SECTION("Debug")
-    {
+    SECTION("Debug") {
         parse(app, {"--log-level", "debug"});
         REQUIRE(args.log_level() == spdlog::level::level_enum::debug);
+    }
+}
+
+TEST_CASE("QueryFilter", "[cli]") {
+    CLI::App app("QueryFilter test");
+    pisa::Args<pisa::arg::Query<pisa::arg::QueryMode::Unranked>, pisa::arg::QueryFilter> args(&app);
+
+    pisa::TemporaryDirectory dir;
+    auto queries = dir.path() / "queries.txt";
+    write_lines(
+        queries,
+        {"1:one", "2:one two", "3:one two three", "4:one two three four", "5:one two three four five"}
+    );
+    auto terms = dir.path() / "terms.txt";
+    // terms must be sorted
+    std::vector<std::string> term_vector = {
+        "five",
+        "four",
+        "one",
+        "three",
+        "two",
+    };
+    auto termlex = pisa::encode_payload_vector(term_vector.begin(), term_vector.end());
+    termlex.to_file(terms.string());
+
+    SECTION("Default") {
+        std::vector<std::string> input{"--queries", queries.string(), "--terms", terms.string()};
+        parse(app, input);
+
+        auto qs = args.queries();
+        auto qs_filtered = args.query_filter_apply(qs);
+
+        REQUIRE(1 == args.query_filter_min_length());
+        REQUIRE(std::numeric_limits<int>::max() == args.query_filter_max_length());
+
+        REQUIRE(5 == qs.size());
+        REQUIRE(5 == qs_filtered.size());
+    }
+
+    SECTION("Filter queries by length") {
+        std::vector<std::string> input{
+            "--queries",
+            queries.string(),
+            "--terms",
+            terms.string(),
+            "--min-query-len",
+            "3",
+            "--max-query-len",
+            "4"
+        };
+        parse(app, input);
+
+        auto qs = args.queries();
+        auto qs_filtered = args.query_filter_apply(qs);
+
+        REQUIRE(3 == args.query_filter_min_length());
+        REQUIRE(4 == args.query_filter_max_length());
+
+        REQUIRE(5 == qs.size());
+        REQUIRE(2 == qs_filtered.size());
+
+        REQUIRE("3" == qs_filtered[0].id());
+        REQUIRE(
+            std::vector<pisa::WeightedTerm>{{2, 1.F}, {4, 1.F}, {3, 1.F}} == qs_filtered[0].terms()
+        );
+
+        REQUIRE("4" == qs_filtered[1].id());
+        REQUIRE(
+            std::vector<pisa::WeightedTerm>{{2, 1.F}, {4, 1.F}, {3, 1.F}, {1, 1.F}}
+            == qs_filtered[1].terms()
+        );
     }
 }


### PR DESCRIPTION
Add CLI option to customize scorer params for BM25 and beyond.
Fixes #392

Changes proposed in this pull request:

- Add `--scorer` option to tools/compute_intersection.cpp
- Update tests/test_intersection.cpp
- Fix logic error when filtering queries by min/max number of terms
