### PR TITLE
`tools/compute_intersection`: do not print empty intersections

### DIFF
--- a/include/pisa/intersection.hpp
+++ b/include/pisa/intersection.hpp
@@ -25,7 +25,7 @@ namespace intersection {
     /// Returns a filtered copy of `query` containing only terms indicated by ones in the bit mask.
     [[nodiscard]] inline auto filter(Query const& query, Mask const& mask) -> Query {
         if (query.terms().size() > MAX_QUERY_LEN) {
-            throw std::invalid_argument("Queries can be at most 2^32 terms long");
+            throw std::invalid_argument("Queries can be at most 2^31 terms long");
         }
         std::vector<std::uint32_t> terms;
         std::vector<float> weights;

--- a/tools/compute_intersection.cpp
+++ b/tools/compute_intersection.cpp
@@ -48,6 +48,9 @@ void intersect(
 
     auto print_intersection = [&](auto const& query, auto const& mask) {
         auto intersection = Intersection::compute(index, wdata, scorer, query, mask);
+        if (0U == intersection.length) {
+            return;
+        }
         std::cout << fmt::format(
             "{}\t{}\t{}\t{}\n",
             query.id() ? *query.id() : std::to_string(qid),
@@ -62,6 +65,9 @@ void intersect(
             for_all_subsets(query, max_term_count, print_intersection);
         } else {
             auto intersection = Intersection::compute(index, wdata, scorer, query);
+            if (0U == intersection.length) {
+                continue;
+            }
             std::cout << fmt::format(
                 "{}\t{}\t{}\n",
                 query.id() ? *query.id() : std::to_string(qid),


### PR DESCRIPTION
This changes `tools/compute_intersection` so that only those queries (with or without the `--combinations` flag, and with or without a `Mask` in `intersection::compute`) with an intersection size greater than zero will be output.

Note, fix typo in `include/intersect.hpp`

Fixes #290