### PR TITLE
Update `invert` tool documentation

### DIFF
--- a/docs/src/guide/inverting.md
+++ b/docs/src/guide/inverting.md
@@ -6,12 +6,15 @@ existence of a forward index in the path `path/to/forward/cw09b`:
 
     $ mkdir -p path/to/inverted
     $ ./invert -i path/to/forward/cw09b \
-        -o path/to/inverted/cw09b \
-        --term-count `wc -w < path/to/forward/cw09b.terms`
+        -o path/to/inverted/cw09b
 
-Note that the script requires as parameter the number of terms to be
-indexed, which is obtained by embedding the
-`wc -w < path/to/forward/cw09b.terms` instruction.
+Inverting an index requires the knowledge of the number of terms in
+the lexicon ahead of time. In the above example, the `invert` command
+assumes that a `cw09b.termlex' file exists from the output of
+`parse_collection` which is used to lookup the term count.
+
+Note that the number of terms can be provided using `--term-count` in
+case the lexicon is not available or on a different path.
 
 ## Inverted index format
 

--- a/tools/app.cpp
+++ b/tools/app.cpp
@@ -171,7 +171,13 @@ auto Threads::print_args(std::ostream& os) const -> std::ostream& {
 Invert::Invert(CLI::App* app) {
     app->add_option("-i,--input", m_input_basename, "Forward index basename")->required();
     app->add_option("-o,--output", m_output_basename, "Output inverted index basename")->required();
-    app->add_option("--term-count", m_term_count, "Number of distinct terms in the forward index");
+    app->add_option(
+        "--term-count",
+        m_term_count,
+        "Number of distinct terms in the forward index.\n"
+        "When omitted, the term count from the lexicon\n"
+        "file `{input}.termlex` is used."
+    );
 }
 
 auto Invert::input_basename() const -> std::string {


### PR DESCRIPTION
Update the documentation for `invert` tool to be inline with the output of the forward index from `parse_collection`.

Updates to CLI and Guide documentation for `invert` are provided.

Fixes #619