### PR TITLE
fix: Use backward-compatible default CLI value

### DIFF
--- a/include/pisa/util/util.hpp
+++ b/include/pisa/util/util.hpp
@@ -113,24 +113,23 @@ function_iterator<State, AdvanceFunctor, ValueFunctor> make_function_iterator(
 }
 
 struct stats_line {
-    stats_line() : m_out(std::cout) { m_out << "{"; }
-    explicit stats_line(std::ostream& out) : m_out(out) { m_out << "{"; }
+    stats_line() { std::cout << "{"; }
     stats_line(stats_line const&) = default;
     stats_line(stats_line&&) noexcept = default;
     stats_line& operator=(stats_line const&) = default;
     stats_line& operator=(stats_line&&) noexcept = default;
-    ~stats_line() { m_out << "}" << std::endl; }
+    ~stats_line() { std::cout << "}" << std::endl; }
 
     template <typename K, typename T>
     stats_line& operator()(K const& key, T const& value) {
         if (!first) {
-            m_out << ", ";
+            std::cout << ", ";
         } else {
             first = false;
         }
 
         emit(key);
-        m_out << ": ";
+        std::cout << ": ";
         emit(value);
         return *this;
     }
@@ -143,27 +142,27 @@ struct stats_line {
   private:
     template <typename T>
     void emit(T const& v) const {
-        m_out << v;
+        std::cout << v;
     }
 
     // XXX properly escape strings
-    void emit(const char* s) const { m_out << '"' << s << '"'; }
+    void emit(const char* s) const { std::cout << '"' << s << '"'; }
 
     void emit(std::string const& s) const { emit(s.c_str()); }
 
     template <typename T>
     void emit(std::vector<T> const& v) const {
-        m_out << "[";
+        std::cout << "[";
         bool first = true;
         for (auto const& i: v) {
             if (first) {
                 first = false;
             } else {
-                m_out << ", ";
+                std::cout << ", ";
             }
             emit(i);
         }
-        m_out << "]";
+        std::cout << "]";
     }
 
     template <typename K, typename V>
@@ -175,7 +174,7 @@ struct stats_line {
     template <typename Tuple, size_t Pos>
     typename std::enable_if<Pos != 0, void>::type emit_tuple_helper(Tuple const& t) const {
         emit_tuple_helper<Tuple, Pos - 1>(t);
-        m_out << ", ";
+        std::cout << ", ";
         emit(std::get<Pos>(t));
     }
 
@@ -186,9 +185,9 @@ struct stats_line {
 
     template <typename... Tp>
     void emit(std::tuple<Tp...> const& t) const {
-        m_out << "[";
+        std::cout << "[";
         emit_tuple_helper<std::tuple<Tp...>, sizeof...(Tp) - 1>(t);
-        m_out << "]";
+        std::cout << "]";
     }
 
     template <typename T1, typename T2>
@@ -196,7 +195,6 @@ struct stats_line {
         emit(std::make_tuple(p.first, p.second));
     }
 
-    std::ostream& m_out;
     bool first{true};
 };
 

--- a/tools/queries.cpp
+++ b/tools/queries.cpp
@@ -460,7 +460,7 @@ using wand_uniform_index_quantized = wand_data<wand_data_compressed<PayloadType:
 int main(int argc, const char** argv) {
     bool safe = false;
     bool quantized = false;
-    std::size_t runs = 0;
+    std::size_t runs = 3;
     std::optional<std::string> output_path;
 
     App<arg::Index,
@@ -474,7 +474,9 @@ int main(int argc, const char** argv) {
     app.add_flag("--quantized", quantized, "Quantized scores");
     app.add_flag("--safe", safe, "Rerun if not enough results with pruning.")
         ->needs(app.thresholds_option());
-    app.add_option("--runs", runs, "Number of runs per query")->default_val(3)->check(CLI::PositiveNumber);
+    app.add_option("--runs", runs, "Number of runs per query")
+        ->capture_default_str()
+        ->check(CLI::PositiveNumber);
     app.add_option("-o,--output", output_path, "Output file for per-run query timing data");
     CLI11_PARSE(app, argc, argv);
 


### PR DESCRIPTION
Use `capture_default_str()` instead of `default_value()` for backward compatibility.

Using `default_value()` failed on one of the tests on `main` that used system dependency for CLI11 that was in a lower version.

---

Also deleting operators that are already implicitly deleted.