### PR TITLE
Fix query algorithm WAND validation and duplicate TSV header in `queries`

### DIFF
--- a/tools/app.cpp
+++ b/tools/app.cpp
@@ -85,12 +85,12 @@ const std::map<std::string, bool> Algorithm::VALID_ALGORITHMS = {
     {"wand", true},
     {"block_max_wand", true},
     {"block_max_maxscore", true},
-    {"ranked_and", false},
+    {"ranked_and", true},
     {"block_max_ranked_and", true},
-    {"ranked_or", false},
+    {"ranked_or", true},
     {"maxscore", true},
-    {"ranked_or_taat", false},
-    {"ranked_or_taat_lazy", false}
+    {"ranked_or_taat", true},
+    {"ranked_or_taat_lazy", true}
 };
 
 LogLevel::LogLevel(CLI::App* app) {

--- a/tools/queries.cpp
+++ b/tools/queries.cpp
@@ -249,7 +249,6 @@ void print_times(
     std::string const& query_type,
     std::ostream& output_stream
 ) {
-    output_stream << "algorithm\tqid\trun\tusec\n";
     for (auto&& [query_idx, query]: enumerate(queries)) {
         for (auto&& [run_idx, time]: enumerate(query_times.values[query_idx])) {
             output_stream << fmt::format(
@@ -326,6 +325,10 @@ void perftest(
     }
 
     auto scorer = scorer::from_params(scorer_params, wdata);
+
+    if (output_file) {
+        *output_file << "algorithm\tqid\trun\tusec\n";
+    }
 
     for (const auto& t: query_types) {
         auto valid_algorithms_it = pisa::arg::Algorithm::VALID_ALGORITHMS.find(t);

--- a/tools/queries.cpp
+++ b/tools/queries.cpp
@@ -328,6 +328,16 @@ void perftest(
     auto scorer = scorer::from_params(scorer_params, wdata);
 
     for (const auto& t: query_types) {
+        auto valid_algorithms_it = pisa::arg::Algorithm::VALID_ALGORITHMS.find(t);
+        if (valid_algorithms_it == pisa::arg::Algorithm::VALID_ALGORITHMS.end()) {
+            spdlog::error("Unsupported query type: {}", t);
+            break;
+        }
+        if (valid_algorithms_it->second && !wand_data_filename) {
+            spdlog::error("Query type '{}' requires WAND data", t);
+            break;
+        }
+
         spdlog::info("Performing {} runs for '{}' queries...", runs, t);
 
         std::function<uint64_t(Query, Score)> query_fun;
@@ -346,7 +356,7 @@ void perftest(
                 or_query<true> or_q;
                 return or_q(make_cursors(index, query), index.num_docs());
             };
-        } else if (t == "wand" && wand_data_filename) {
+        } else if (t == "wand") {
             query_fun = [&](Query query, Score threshold) {
                 topk_queue topk(k, threshold);
                 wand_query wand_q(topk);
@@ -356,7 +366,7 @@ void perftest(
                 topk.finalize();
                 return topk.topk().size();
             };
-        } else if (t == "block_max_wand" && wand_data_filename) {
+        } else if (t == "block_max_wand") {
             query_fun = [&](Query query, Score threshold) {
                 topk_queue topk(k, threshold);
                 block_max_wand_query block_max_wand_q(topk);
@@ -367,7 +377,7 @@ void perftest(
                 topk.finalize();
                 return topk.topk().size();
             };
-        } else if (t == "block_max_maxscore" && wand_data_filename) {
+        } else if (t == "block_max_maxscore") {
             query_fun = [&](Query query, Score threshold) {
                 topk_queue topk(k, threshold);
                 block_max_maxscore_query block_max_maxscore_q(topk);
@@ -378,7 +388,7 @@ void perftest(
                 topk.finalize();
                 return topk.topk().size();
             };
-        } else if (t == "ranked_and" && wand_data_filename) {
+        } else if (t == "ranked_and") {
             query_fun = [&](Query query, Score threshold) {
                 topk_queue topk(k, threshold);
                 ranked_and_query ranked_and_q(topk);
@@ -386,7 +396,7 @@ void perftest(
                 topk.finalize();
                 return topk.topk().size();
             };
-        } else if (t == "block_max_ranked_and" && wand_data_filename) {
+        } else if (t == "block_max_ranked_and") {
             query_fun = [&](Query query, Score threshold) {
                 topk_queue topk(k, threshold);
                 block_max_ranked_and_query block_max_ranked_and_q(topk);
@@ -397,7 +407,7 @@ void perftest(
                 topk.finalize();
                 return topk.topk().size();
             };
-        } else if (t == "ranked_or" && wand_data_filename) {
+        } else if (t == "ranked_or") {
             query_fun = [&](Query query, Score threshold) {
                 topk_queue topk(k, threshold);
                 ranked_or_query ranked_or_q(topk);
@@ -405,7 +415,7 @@ void perftest(
                 topk.finalize();
                 return topk.topk().size();
             };
-        } else if (t == "maxscore" && wand_data_filename) {
+        } else if (t == "maxscore") {
             query_fun = [&](Query query, Score threshold) {
                 topk_queue topk(k, threshold);
                 maxscore_query maxscore_q(topk);
@@ -415,7 +425,7 @@ void perftest(
                 topk.finalize();
                 return topk.topk().size();
             };
-        } else if (t == "ranked_or_taat" && wand_data_filename) {
+        } else if (t == "ranked_or_taat") {
             SimpleAccumulator accumulator(index.num_docs());
             topk_queue topk(k);
             query_fun = [&, topk, accumulator](Query query, Score threshold) mutable {
@@ -427,7 +437,7 @@ void perftest(
                 topk.finalize();
                 return topk.topk().size();
             };
-        } else if (t == "ranked_or_taat_lazy" && wand_data_filename) {
+        } else if (t == "ranked_or_taat_lazy") {
             LazyAccumulator<4> accumulator(index.num_docs());
             topk_queue topk(k);
             query_fun = [&, topk, accumulator](Query query, Score threshold) mutable {
@@ -439,9 +449,6 @@ void perftest(
                 topk.finalize();
                 return topk.topk().size();
             };
-        } else {
-            spdlog::error("Unsupported query type: {}", t);
-            break;
         }
         auto query_times = extract_times(query_fun, queries, thresholds, runs, k, safe);
         print_summary(query_times, type, t, runs, k, safe);

--- a/tools/tests/test_app.cpp
+++ b/tools/tests/test_app.cpp
@@ -410,22 +410,57 @@ TEST_CASE("Algorithm", "[cli]") {
     }
 }
 
+TEST_CASE("Algorithm WAND requirement mapping is correct", "[cli]") {
+    auto const& algorithms = pisa::arg::Algorithm::VALID_ALGORITHMS;
+    REQUIRE(algorithms.size() == 12);
+
+    REQUIRE(algorithms.at("and") == false);
+    REQUIRE(algorithms.at("or") == false);
+    REQUIRE(algorithms.at("or_freq") == false);
+    REQUIRE(algorithms.at("wand") == true);
+    REQUIRE(algorithms.at("block_max_wand") == true);
+    REQUIRE(algorithms.at("block_max_maxscore") == true);
+    REQUIRE(algorithms.at("ranked_and") == true);
+    REQUIRE(algorithms.at("block_max_ranked_and") == true);
+    REQUIRE(algorithms.at("ranked_or") == true);
+    REQUIRE(algorithms.at("maxscore") == true);
+    REQUIRE(algorithms.at("ranked_or_taat") == true);
+    REQUIRE(algorithms.at("ranked_or_taat_lazy") == true);
+}
+
 TEST_CASE("Algorithm requires WAND data", "[cli]") {
-    CLI::App app("Algorithm WAND test");
-    pisa::Args<pisa::arg::WandData<pisa::arg::WandMode::Optional>, pisa::arg::Algorithm> args(&app);
-    SECTION("Algorithm not requiring WAND without WAND data succeeds") {
-        REQUIRE_NOTHROW(parse(app, {"-a", "and"}));
+    SECTION("Single algorithm without WAND data throws when required") {
+        for (auto const& [algorithm, requires_wand]: pisa::arg::Algorithm::VALID_ALGORITHMS) {
+            CAPTURE(algorithm, requires_wand);
+            CLI::App app("Algorithm WAND test");
+            pisa::Args<pisa::arg::WandData<pisa::arg::WandMode::Optional>, pisa::arg::Algorithm> args(
+                &app
+            );
+            if (requires_wand) {
+                REQUIRE_THROWS(parse(app, {"-a", algorithm}));
+            } else {
+                REQUIRE_NOTHROW(parse(app, {"-a", algorithm}));
+            }
+        }
     }
-    SECTION("Algorithm requiring WAND without WAND data throws") {
-        REQUIRE_THROWS(parse(app, {"-a", "wand"}));
+    SECTION("Single algorithm with WAND data always succeeds") {
+        for (auto const& [algorithm, requires_wand]: pisa::arg::Algorithm::VALID_ALGORITHMS) {
+            CAPTURE(algorithm, requires_wand);
+            CLI::App app("Algorithm WAND test");
+            pisa::Args<pisa::arg::WandData<pisa::arg::WandMode::Optional>, pisa::arg::Algorithm> args(
+                &app
+            );
+            REQUIRE_NOTHROW(parse(app, {"-a", algorithm, "-w", "WDATA"}));
+        }
     }
-    SECTION("Algorithm requiring WAND with WAND data succeeds") {
-        REQUIRE_NOTHROW(parse(app, {"-a", "wand", "-w", "WDATA"}));
-    }
-    SECTION("Multiple algorithms with one requiring WAND without WAND data throws") {
+    SECTION("Multiple algorithms without WAND data throws when one requires it") {
+        CLI::App app("Algorithm WAND test");
+        pisa::Args<pisa::arg::WandData<pisa::arg::WandMode::Optional>, pisa::arg::Algorithm> args(&app);
         REQUIRE_THROWS(parse(app, {"-a", "and", "-a", "maxscore"}));
     }
-    SECTION("Multiple algorithms with one requiring WAND with WAND data succeeds") {
+    SECTION("Multiple algorithms with WAND data succeeds when one requires it") {
+        CLI::App app("Algorithm WAND test");
+        pisa::Args<pisa::arg::WandData<pisa::arg::WandMode::Optional>, pisa::arg::Algorithm> args(&app);
         REQUIRE_NOTHROW(parse(app, {"-a", "and", "-a", "maxscore", "-w", "WDATA"}));
     }
 }


### PR DESCRIPTION
Key changes in this pull request: 
1. Fix `ranked_and`, `ranked_or`, `ranked_or_taat`, `ranked_or_taat_lazy` incorrectly marked as not requiring WAND data in `VALID_ALGORITHMS`. This did not cause issues because the check was correctly enforced at runtime.
2. Centralize WAND data validation using `VALID_ALGORITHMS` instead of duplicating check in `queries`, reducing the need for double checks when modifying the logic. 
3. Fix duplicate TSV header when running `queries` using multiple algorithms (previously printed for each algorithm).